### PR TITLE
Remove esLintPlugin from vite local dev

### DIFF
--- a/.github/workflows/eslint-build.yml
+++ b/.github/workflows/eslint-build.yml
@@ -1,0 +1,25 @@
+# runs a build to make sure that no eslint rules or build issues happen.
+# this must be successful before continuing with a pull request
+on:
+  # Trigger analysis when pushing in master or pull requests, and when creating a pull request.
+  push:
+    branches:
+      - dev
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+name: DEV ESlint Build
+jobs:
+  sonarcloud:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # Disabling shallow clone is recommended for improving relevancy of reporting
+          fetch-depth: 0
+      - name: Build
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm install
+      - run: |
+          npm run buildtest

--- a/utah-design-system-website/package.json
+++ b/utah-design-system-website/package.json
@@ -14,11 +14,11 @@
     "testOnce": "vitest run"
   },
   "dependencies": {
+    "@popperjs/core": "2.11.8",
     "@utahdts/utah-design-system": "1.5.1",
     "@utahdts/utah-design-system-header": "1.5.1",
     "js-beautify": "1.14.9",
     "lodash": "4.17.21",
-    "@popperjs/core": "2.11.8",
     "prop-types": "15.8.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/utah-design-system-website/vite.config.js
+++ b/utah-design-system-website/vite.config.js
@@ -20,7 +20,8 @@ export default defineConfig(({ command, mode, ssrBuild }) => {
     },
     plugins: [
       react(),
-      eslintPlugin(),
+      // fail on eslint errors for build, but don't slow dev down
+      mode === 'production-website' ? eslintPlugin() : null,
       mkcert({
         force: true,
         hosts: ['*.utah.gov', '*.local.utah.gov', '127.0.0.1', 'localhost', '::1'],
@@ -34,7 +35,6 @@ export default defineConfig(({ command, mode, ssrBuild }) => {
     },
     preview: {
       port: 8080,
-    },
-    logLevel: 'silent'
+    }
   };
 });


### PR DESCRIPTION
The esLintPlugin was causing the local HMR vite to be SUPER slow (10seconds vs 5 seconds). By removing
eslint, vite now is more usable. BUT it won't die if there are eslint errors. We do want to have to fix eslint errors so we are pushing the error checking to the build process. We won't get live eslint errors, but it will still correctly bite us.

The eslint-build.yml file now runs on pull-requests to make sure there are no eslint errors.