### PR TITLE
V1.15.3 fixes

### DIFF
--- a/@utahdts/utah-design-system-header/src/css/_logos.scss
+++ b/@utahdts/utah-design-system-header/src/css/_logos.scss
@@ -1,3 +1,5 @@
+@use "../../../utah-design-system//css/1-settings/media-size-vars";
+
 .utah-design-system {
   .utds {
     &-logo-wrapper {
@@ -41,7 +43,11 @@
           max-height: 100%;
         }
         img {
-          max-width: none;
+          height: auto;
+          &[src*=".svg"] {
+            height: 100%;
+            max-width: 100%;
+          }
         }
       }
       &__title {
@@ -102,6 +108,16 @@
   }
   a[href].utds-title-wrapper {
     text-decoration: none;
+  }
+}
+
+@media screen and (max-width: #{media-size-vars.$media-size-tablet-portrait}) {
+  .utah-design-system {
+    .utds {
+      &-title-wrapper {
+        font-size: var(--font-size-xl);
+      }
+    }
   }
 }
 

--- a/@utahdts/utah-design-system-header/src/js/renderables/popupMenu/renderPopupMenu.js
+++ b/@utahdts/utah-design-system-header/src/js/renderables/popupMenu/renderPopupMenu.js
@@ -125,9 +125,6 @@ function renderPopupMenuItem(menuUl, popupMenuItem, options) {
     throw new Error('renderPopupMenuItem: titleSpanLink not found');
   }
 
-  menuAHref.onclick = onClickBlur;
-  menuButton.onclick = onClickBlur;
-
   const actionMenu = popupMenuItem.actionMenu && [...popupMenuItem.actionMenu];
   // add "(page)" menu item if menu item is an actionMenu && a link
   if (actionMenu && (
@@ -143,6 +140,11 @@ function renderPopupMenuItem(menuUl, popupMenuItem, options) {
       icon: popupMenuItem.icon,
       title: `${popupMenuItem.title} (page)`,
     });
+  }
+
+  if (!actionMenu?.length) {
+    menuAHref.onclick = onClickBlur;
+    menuButton.onclick = onClickBlur;
   }
 
   // three types of action: parent, custom function, link

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# [1.15.2] 1/31/2024
+# [1.15.3] 2/26/2024
+## Fixed
+- Fix menus not popping open on a touch device
+- Fix overflowing utah header logo
+- Fix overflowing utah header text
+
+# [1.15.2] 2/14/2024
 ## Fixed
 - Add styles for other types of text inputs
 


### PR DESCRIPTION
# [1.15.3] 2/26/2024
## Fixed
- Fix menus not popping open on a touch device
- Fix overflowing utah header logo
- Fix overflowing utah header text