### PR TITLE
fix: Remove aria-expanded from menu items

### DIFF
--- a/@utahdts/utah-design-system-header/package.json
+++ b/@utahdts/utah-design-system-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utahdts/utah-design-system-header",
-  "version": "1.15.3",
+  "version": "1.16.0",
   "description": "Utah Header for the Utah Design System",
   "exports": {
     ".": {

--- a/@utahdts/utah-design-system-header/src/js/lifecycle/globalEvents.js
+++ b/@utahdts/utah-design-system-header/src/js/lifecycle/globalEvents.js
@@ -1,4 +1,5 @@
 import { domConstants, getCssClassSelector } from '../enumerations/domConstants';
+import { allowAriaExpanded } from '../misc/allowAriaExpanded';
 import { showHideElement } from '../misc/showHideElement';
 
 /** @typedef {import('src/@types/jsDocTypes.d').GlobalEventType} GlobalEventType */
@@ -34,7 +35,7 @@ export function hideAllMenus() {
       const popupId = popup.getAttribute('id');
       if (popupId) {
         const controllingElement = document.querySelector(`[aria-controls="${popupId}"]`);
-        if (controllingElement) {
+        if (controllingElement && allowAriaExpanded(controllingElement)) {
           controllingElement.setAttribute('aria-expanded', 'false');
         }
       }

--- a/@utahdts/utah-design-system-header/src/js/misc/allowAriaExpanded.js
+++ b/@utahdts/utah-design-system-header/src/js/misc/allowAriaExpanded.js
@@ -1,0 +1,10 @@
+/**
+ * menus do not use aria-expanded because the popups are always rendered and only
+ * shown/hid. Yet to spring readers, they are always visible so they don't need to
+ * report expanded.
+ * @param {Element} element
+ * @returns {boolean}
+ */
+export function allowAriaExpanded(element) {
+  return !element.closest('.menu-item__title') && !element.closest('.vertical-menu__title');
+}

--- a/@utahdts/utah-design-system-header/src/js/misc/popupFocusHandler.js
+++ b/@utahdts/utah-design-system-header/src/js/misc/popupFocusHandler.js
@@ -2,6 +2,7 @@ import { createPopper } from '@popperjs/core';
 import { domConstants, getCssClassSelector } from '../enumerations/domConstants';
 import { PopupPlacement } from '../enumerations/popupPlacement';
 import { hideAllMenus } from '../lifecycle/globalEvents';
+import { allowAriaExpanded } from './allowAriaExpanded';
 import { checkForError } from './checkForError';
 import { isTouchDevice } from './isTouchDevice';
 import { showHideElement } from './showHideElement';
@@ -72,7 +73,9 @@ export function popupFocusHandler(wrapper, button, popup, ariaHasPopup, options)
   const TIMEOUT_MS_MEDIUM = 150;
   const TIMEOUT_MS_SHORT = 50;
 
-  button.setAttribute('aria-expanded', 'false');
+  if (allowAriaExpanded(button)) {
+    button.setAttribute('aria-expanded', 'false');
+  }
   button.setAttribute('aria-haspopup', ariaHasPopup);
 
   /*
@@ -101,7 +104,9 @@ export function popupFocusHandler(wrapper, button, popup, ariaHasPopup, options)
             ],
           });
           showHideElement(popup, true, domConstants.POPUP__VISIBLE, domConstants.POPUP__HIDDEN);
-          button.setAttribute('aria-expanded', 'true');
+          if (allowAriaExpanded(button)) {
+            button.setAttribute('aria-expanded', 'true');
+          }
 
           // hide all tooltips
           document.querySelectorAll(getCssClassSelector(domConstants.TOOLTIP__WRAPPER))
@@ -128,7 +133,9 @@ export function popupFocusHandler(wrapper, button, popup, ariaHasPopup, options)
       delayHideTimeoutId = window.setTimeout(
         () => {
           showHideElement(popup, false, domConstants.POPUP__VISIBLE, domConstants.POPUP__HIDDEN);
-          button.setAttribute('aria-expanded', 'false');
+          if (allowAriaExpanded(button)) {
+            button.setAttribute('aria-expanded', 'false');
+          }
         },
         delayMS
       );

--- a/@utahdts/utah-design-system-header/src/js/renderables/popupMenu/renderPopupMenu.js
+++ b/@utahdts/utah-design-system-header/src/js/renderables/popupMenu/renderPopupMenu.js
@@ -15,6 +15,7 @@ import PopupMenuItemHtml from './html/PopupMenuItem.html?raw';
 import { childrenMenuTypes } from '../../enumerations/childrenMenuTypes';
 import { domConstants, getCssClassSelector } from '../../enumerations/domConstants';
 import { PopupPlacement } from '../../enumerations/popupPlacement';
+import { allowAriaExpanded } from '../../misc/allowAriaExpanded';
 import { findRecursive } from '../../misc/findRecursive';
 import { popupFocusHandler } from '../../misc/popupFocusHandler';
 import { renderDOMSingle } from '../../misc/renderDOMSingle';
@@ -51,11 +52,15 @@ function toggleChildMenuExpansion(element) {
       // toggle child menu items open close
       childUl.classList.toggle(domConstants.VISUALLY_HIDDEN);
       if (childUl.classList.contains(domConstants.VISUALLY_HIDDEN)) {
-        button.setAttribute('aria-expanded', 'false');
+        if (allowAriaExpanded(button)) {
+          button.setAttribute('aria-expanded', 'false');
+        }
         chevron.classList.add(domConstants.IS_CLOSED);
         chevron.classList.remove(domConstants.IS_OPEN);
       } else {
-        button.setAttribute('aria-expanded', 'true');
+        if (allowAriaExpanded(button)) {
+          button.setAttribute('aria-expanded', 'true');
+        }
         chevron.classList.remove(domConstants.IS_CLOSED);
         chevron.classList.add(domConstants.IS_OPEN);
       }
@@ -196,7 +201,9 @@ function renderPopupMenuItem(menuUl, popupMenuItem, options) {
         subMenu.classList.add(domConstants.VISUALLY_HIDDEN);
         menuItemWrapper.appendChild(subMenu);
         menuButton.onclick = handleMenuExpansion(menuButton);
-        menuButton.setAttribute('aria-expanded', 'false');
+        if (allowAriaExpanded(menuButton)) {
+          menuButton.setAttribute('aria-expanded', 'false');
+        }
         menuButton.setAttribute('aria-controls', subMenuId);
         chevron = renderChevron();
         menuButton.appendChild(chevron);
@@ -210,7 +217,9 @@ function renderPopupMenuItem(menuUl, popupMenuItem, options) {
           // if e.target is switched to e.currenttarget then tabbing through child popup menus does not open the children
           for (let childUl = /** @type {Element | null | undefined} */(e.target)?.closest('ul'); childUl; childUl = childUl.parentElement?.closest('ul')) {
             childUl.classList.remove(domConstants.VISUALLY_HIDDEN);
-            menuButton.setAttribute('aria-expanded', 'true');
+            if (allowAriaExpanded(menuButton)) {
+              menuButton.setAttribute('aria-expanded', 'true');
+            }
             // if target is the button then don't expand chevron just yet, wait for a child to be visible
             // (happens when tabbing to the chevron menu item)
             // using e.currentTarget caused the chevron to expand on the parent before the children were tabbed into

--- a/@utahdts/utah-design-system/package.json
+++ b/@utahdts/utah-design-system/package.json
@@ -77,7 +77,7 @@
   },
   "devDependencies": {
     "@types/lodash": "4.14.202",
-    "@types/react": "18.2.48",
+    "@types/react": "18.2.79",
     "@types/react-dom": "18.2.18",
     "@types/uuid": "9.0.8",
     "@vitejs/plugin-react": "4.2.1",

--- a/@utahdts/utah-design-system/package.json
+++ b/@utahdts/utah-design-system/package.json
@@ -2,7 +2,7 @@
   "name": "@utahdts/utah-design-system",
   "description": "Utah Design System React Library",
   "displayName": "Utah Design System React Library",
-  "version": "1.15.3",
+  "version": "1.16.0",
   "exports": {
     ".": {
       "development-local": "./index.js",
@@ -65,7 +65,7 @@
   },
   "homepage": "https://github.com/utahdts/utah-design-system",
   "dependencies": {
-    "@utahdts/utah-design-system-header": "1.15.3",
+    "@utahdts/utah-design-system-header": "1.16.0",
     "date-fns": "3.3.1",
     "lodash": "4.17.21",
     "prop-types": "15.8.1",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [1.16.0] 4/16/2024
+## Fixed
+- Allow color picker to be dragged around screen
+- Allow opening child flyouts on mobile
+- Remove `aria-expanded` from main menu items
+
+## Added
+- Option to allow custom items in MultiSelect
+- PlainText component
+- TimeInput component
+- Vertical Menu sandbox in documentation
+
 # [1.15.3] 2/26/2024
 ## Fixed
 - Fix menus not popping open on a touch device

--- a/examples/design-system/vite-react/package.json
+++ b/examples/design-system/vite-react/package.json
@@ -15,7 +15,7 @@
     "react-dom": "18.2.0"
   },
   "devDependencies": {
-    "@types/react": "18.2.48",
+    "@types/react": "18.2.79",
     "@types/react-dom": "18.2.18",
     "@vitejs/plugin-react": "4.2.1",
     "eslint": "8.56.0",

--- a/examples/design-system/vite-react/package.json
+++ b/examples/design-system/vite-react/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@utahdts/utah-design-system": "1.15.3",
+    "@utahdts/utah-design-system": "1.16.0",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },

--- a/examples/typed/typed-utah-header/package.json
+++ b/examples/typed/typed-utah-header/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@utahdts/utah-design-system-header": "1.15.3",
+    "@utahdts/utah-design-system-header": "1.16.0",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },

--- a/examples/typed/typed-utah-header/package.json
+++ b/examples/typed/typed-utah-header/package.json
@@ -15,7 +15,7 @@
     "react-dom": "18.2.0"
   },
   "devDependencies": {
-    "@types/react": "18.2.48",
+    "@types/react": "18.2.79",
     "@types/react-dom": "18.2.18",
     "@typescript-eslint/eslint-plugin": "6.7.0",
     "@typescript-eslint/parser": "6.7.0",

--- a/examples/utah-header/vite/package.json
+++ b/examples/utah-header/vite/package.json
@@ -12,6 +12,6 @@
     "vite": "5.0.12"
   },
   "dependencies": {
-    "@utahdts/utah-design-system-header": "1.15.3"
+    "@utahdts/utah-design-system-header": "1.16.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "design-system-packages",
-  "version": "1.15.3",
+  "version": "1.16.0",
   "workspaces": [
     "@utahdts/utah-design-system-header",
     "@utahdts/utah-design-system",

--- a/utah-design-system-website/package.json
+++ b/utah-design-system-website/package.json
@@ -35,7 +35,7 @@
     "use-immer": "0.9.0"
   },
   "devDependencies": {
-    "@types/react": "18.2.48",
+    "@types/react": "18.2.79",
     "@types/react-dom": "18.2.18",
     "@types/tinycolor2": "1.4.6",
     "@vitejs/plugin-react": "4.2.1",

--- a/utah-design-system-website/package.json
+++ b/utah-design-system-website/package.json
@@ -1,7 +1,7 @@
 {
   "name": "utah-design-system-website",
   "private": true,
-  "version": "1.15.3",
+  "version": "1.16.0",
   "type": "module",
   "scripts": {
     "dev": "vite --mode development-local",
@@ -21,8 +21,8 @@
   },
   "dependencies": {
     "@popperjs/core": "2.11.8",
-    "@utahdts/utah-design-system": "1.15.3",
-    "@utahdts/utah-design-system-header": "1.15.3",
+    "@utahdts/utah-design-system": "1.16.0",
+    "@utahdts/utah-design-system-header": "1.16.0",
     "date-fns": "3.3.1",
     "js-beautify": "1.14.11",
     "lodash": "4.17.21",


### PR DESCRIPTION
These items are rendered but hidden so they are
always visible to a screen reader so verbalizing
if they are expanded or not doesn't make sense
to a screen reader.

UDS-1500