### PR TITLE
fix: Make main menu actionFunctionUrl items be buttons

### DIFF
--- a/@utahdts/utah-design-system-header/src/js/renderables/mainMenu/renderMainMenu.js
+++ b/@utahdts/utah-design-system-header/src/js/renderables/mainMenu/renderMainMenu.js
@@ -91,12 +91,12 @@ export function renderMainMenu() {
       }
 
       let menuItemTitleElement;
-      if (menuItem.actionFunctionUrl || menuItem.actionUrl) {
-        menuItemTitleElement = mainMenuItemLinkTitle;
-        mainMenuItemButtonTitle.remove();
-      } else if (menuItem.actionMenu || menuItem.actionFunction) {
+      if (menuItem.actionMenu || menuItem.actionFunction) {
         menuItemTitleElement = mainMenuItemButtonTitle;
         mainMenuItemLinkTitle.remove();
+      } else if (menuItem.actionFunctionUrl || menuItem.actionUrl) {
+        menuItemTitleElement = mainMenuItemLinkTitle;
+        mainMenuItemButtonTitle.remove();
       } else {
         throw new Error(`renderMainMenu(): menuItem is missing an action: ${menuItem.title}`);
       }
@@ -121,8 +121,8 @@ export function renderMainMenu() {
         // the sub menu AND clicked to got to the link
         if (
           (menuItem.actionFunction
-          || menuItem.actionUrl
-          || menuItem.actionFunctionUrl)
+            || menuItem.actionUrl
+            || menuItem.actionFunctionUrl)
           && !menuItem.isOverviewHidden
         ) {
           // add `parentMenuLinkSuffix` menu item to top of children menu

--- a/@utahdts/utah-design-system-header/test/dom/renderMenu/parentWithLinkAndChildren.test.js
+++ b/@utahdts/utah-design-system-header/test/dom/renderMenu/parentWithLinkAndChildren.test.js
@@ -225,7 +225,7 @@ describe('renderMenu: parentWithLinkAndChildren - main menu has children & actio
     loadHeader();
 
     testHasMainMenuExists();
-    testMainMenuItemIsA(URL_MENU_ITEM_1, DONT_TOUCH);
+    testMainMenuItemIsButton(DONT_TOUCH);
 
     // has child
     const menuItem1ChildrenMenu = testMainMenuHasChildren();
@@ -267,7 +267,7 @@ describe('renderMenu: parentWithLinkAndChildren - main menu has children & actio
     loadHeader();
 
     testHasMainMenuExists();
-    testMainMenuItemIsA(URL_MENU_ITEM_1, DONT_TOUCH);
+    testMainMenuItemIsButton(DONT_TOUCH);
 
     // has child
     const menuItem1ChildrenMenu = testMainMenuHasChildren();
@@ -309,7 +309,7 @@ describe('renderMenu: parentWithLinkAndChildren - main menu has children & actio
     loadHeader();
 
     testHasMainMenuExists();
-    testMainMenuItemIsA(URL_MENU_ITEM_1, DONT_TOUCH);
+    testMainMenuItemIsButton(DONT_TOUCH);
 
     // has child
     const menuItem1ChildrenMenu = testMainMenuHasChildren();

--- a/examples/design-system/vite-react/package.json
+++ b/examples/design-system/vite-react/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@utahdts/utah-design-system": "2.0.3",
-    "@utahdts/utah-design-system-header": "2.0.2",
+    "@utahdts/utah-design-system-header": "2.0.3",
     "react": "18.3.1",
     "react-dom": "18.3.1"
   },


### PR DESCRIPTION
If a main menu item is both a menu AND an actionFunctionUrl, then the developer is up in the night. But main men items that have a children menus must be a button so that screen readers read them correctly. If they are hrefs then the screen reader doesn't say it the same way as other menus with children.

UDS-1684