### PR TITLE
Bug when clearing single tag in MultiSelect

### DIFF
--- a/@utahdts/utah-design-system/react/components/forms/MultiSelect/MultiSelectTagWrapper.jsx
+++ b/@utahdts/utah-design-system/react/components/forms/MultiSelect/MultiSelectTagWrapper.jsx
@@ -68,7 +68,6 @@ export function MultiSelectTagWrapper({ children, selectedOption, selectedValueI
               selectedValueIndex,
               selectedOption,
               multiSelectContextNonStateRef,
-              multiSelectContext.onChange
             );
           });
         } else if (e.code === 'ArrowLeft') {

--- a/@utahdts/utah-design-system/react/components/forms/MultiSelect/MultiSelectTags.jsx
+++ b/@utahdts/utah-design-system/react/components/forms/MultiSelect/MultiSelectTags.jsx
@@ -59,7 +59,6 @@ export function MultiSelectTags({ isDisabled }) {
                                   selectedValueIndex,
                                   selectedOption,
                                   multiSelectContextNonStateRef,
-                                  multiSelectContext.onChange
                                 );
                               })
                             )

--- a/@utahdts/utah-design-system/react/components/forms/MultiSelect/functions/removeSelectedOption.jsx
+++ b/@utahdts/utah-design-system/react/components/forms/MultiSelect/functions/removeSelectedOption.jsx
@@ -9,13 +9,10 @@
  * @param {number} selectedValueIndex the index of the tag being deleted
  * @param {ComboBoxOptionType} selectedOption the option being removed
  * @param {import('react').MutableRefObject<MultiSelectContextNonStateRef> | null} multiSelectContextNonStateRef
- * @param {(newValues: string[]) => void} onChange
  */
-export function removeSelectedOption(draftContext, addPoliteMessage, selectedValueIndex, selectedOption, multiSelectContextNonStateRef, onChange) {
+export function removeSelectedOption(draftContext, addPoliteMessage, selectedValueIndex, selectedOption, multiSelectContextNonStateRef) {
   // remove from selected values
   draftContext.selectedValues.splice(selectedValueIndex, 1);
-
-  onChange(JSON.parse(JSON.stringify(draftContext.selectedValues)));
 
   addPoliteMessage(`Removed ${selectedOption?.label}`);
 


### PR DESCRIPTION
When clearing a tag in the MultiSelect component, it would triggers the onChange event indefinitely. 