### PR TITLE
UDS-1946

### DIFF
--- a/@utahdts/utah-design-system-header/artifacts/index.d.ts
+++ b/@utahdts/utah-design-system-header/artifacts/index.d.ts
@@ -8,7 +8,7 @@ declare module "@utahdts/utah-design-system-header" {
   export type Environments = "none" | "a1" | "a2" | "a3" | "custom" | "unittest";
   export type Events = "utahHeaderLoaded" | "utahHeaderUnloaded";
   export type HeaderApplicationTypes = 'wordpress' | 'static site' | 'salesforce' | 'custom application' | 'microsoft power apps' | 'servicenow';
-  export type PopupPlacement = "auto" | "auto-start" | "auto-end" | "bottom" | "bottom-start" | "bottom-end" | "left" | "left-start" | "left-end" | "right" | "right-start" | "right-end" | "top" | "top-start" | "top-end";
+  export type PopupPlacement = "bottom" | "bottom-start" | "bottom-end" | "left" | "left-start" | "left-end" | "right" | "right-start" | "right-end" | "top" | "top-start" | "top-end";
   export type Size = "SMALL" | "MEDIUM" | "LARGE";
   export type UtahIdFetchStyle = "Automatic" | "None" | "Provided";
   export type MainMenuItem = {

--- a/@utahdts/utah-design-system-header/src/@types/jsDocTypes.d.js
+++ b/@utahdts/utah-design-system-header/src/@types/jsDocTypes.d.js
@@ -37,8 +37,7 @@
 /**
  * these match the popper's position options
  * PopupPlacement
- * @typedef {'auto' | 'auto-start' | 'auto-end' |
- *   'bottom' | 'bottom-start' | 'bottom-end' |
+ * @typedef { 'bottom' | 'bottom-start' | 'bottom-end' |
  *    'left' | 'left-start' | 'left-end' |
  *    'right' | 'right-start' | 'right-end' |
  *    'top' | 'top-start' | 'top-end'

--- a/@utahdts/utah-design-system-header/src/js/enumerations/popupPlacement.js
+++ b/@utahdts/utah-design-system-header/src/js/enumerations/popupPlacement.js
@@ -12,9 +12,6 @@
 
 /** @enum {PopupPlacementType} */
 export const PopupPlacement = {
-  AUTO: /** @type {PopupPlacementType} */ ('auto'),
-  AUTO_START: /** @type {PopupPlacementType} */ ('auto-start'),
-  AUTO_END: /** @type {PopupPlacementType} */ ('auto-end'),
   BOTTOM: /** @type {PopupPlacementType} */ ('bottom'),
   BOTTOM_START: /** @type {PopupPlacementType} */ ('bottom-start'),
   BOTTOM_END: /** @type {PopupPlacementType} */ ('bottom-end'),

--- a/@utahdts/utah-design-system/@types/jsDocTypes.d.js
+++ b/@utahdts/utah-design-system/@types/jsDocTypes.d.js
@@ -70,8 +70,7 @@
 /**
  * these match the popper's position options
  * PopupPlacement
- * @typedef {'auto' | 'auto-start' | 'auto-end' |
- *   'bottom' | 'bottom-start' | 'bottom-end' |
+ * @typedef { 'bottom' | 'bottom-start' | 'bottom-end' |
  *    'left' | 'left-start' | 'left-end' |
  *    'right' | 'right-start' | 'right-end' |
  *    'top' | 'top-start' | 'top-end'

--- a/@utahdts/utah-design-system/css/6-components/base-components/popups/_popups.scss
+++ b/@utahdts/utah-design-system/css/6-components/base-components/popups/_popups.scss
@@ -77,7 +77,7 @@ $dsc: rgb(0, 0, 0);
       }
     }
 
-    &__wrapper[data-popper-placement^="top"] {
+    &__wrapper[data-poppup-placement^="top"] {
       .popup__content {
         transform-origin: bottom;
       }
@@ -90,7 +90,7 @@ $dsc: rgb(0, 0, 0);
       }
     }
 
-    &__wrapper[data-popper-placement^="bottom"] {
+    &__wrapper[data-poppup-placement^="bottom"] {
       .popup__content {
         transform-origin: top;
       }
@@ -103,7 +103,7 @@ $dsc: rgb(0, 0, 0);
       }
     }
 
-    &__wrapper[data-popper-placement^="left"] {
+    &__wrapper[data-poppup-placement^="left"] {
       .popup__content {
         transform-origin: right;
       }
@@ -116,7 +116,7 @@ $dsc: rgb(0, 0, 0);
       }
     }
 
-    &__wrapper[data-popper-placement^="right"] {
+    &__wrapper[data-poppup-placement^="right"] {
       .popup__content {
         transform-origin: left;
       }

--- a/@utahdts/utah-design-system/css/6-components/base-components/popups/_popups.scss
+++ b/@utahdts/utah-design-system/css/6-components/base-components/popups/_popups.scss
@@ -77,7 +77,7 @@ $dsc: rgb(0, 0, 0);
       }
     }
 
-    &__wrapper[data-poppup-placement^="top"] {
+    &__wrapper[data-popup-placement^="top"] {
       .popup__content {
         transform-origin: bottom;
       }
@@ -90,7 +90,7 @@ $dsc: rgb(0, 0, 0);
       }
     }
 
-    &__wrapper[data-poppup-placement^="bottom"] {
+    &__wrapper[data-popup-placement^="bottom"] {
       .popup__content {
         transform-origin: top;
       }
@@ -103,7 +103,7 @@ $dsc: rgb(0, 0, 0);
       }
     }
 
-    &__wrapper[data-poppup-placement^="left"] {
+    &__wrapper[data-popup-placement^="left"] {
       .popup__content {
         transform-origin: right;
       }
@@ -116,7 +116,7 @@ $dsc: rgb(0, 0, 0);
       }
     }
 
-    &__wrapper[data-poppup-placement^="right"] {
+    &__wrapper[data-popup-placement^="right"] {
       .popup__content {
         transform-origin: left;
       }

--- a/@utahdts/utah-design-system/css/6-components/base-components/popups/_tooltips.scss
+++ b/@utahdts/utah-design-system/css/6-components/base-components/popups/_tooltips.scss
@@ -59,7 +59,7 @@
       }
     }
 
-    &__wrapper[data-popper-placement^="top"] {
+    &__wrapper[data-poppup-placement^="top"] {
       .tooltip__content {
         transform-origin: bottom;
       }
@@ -68,7 +68,7 @@
       }
     }
 
-    &__wrapper[data-popper-placement^="bottom"] {
+    &__wrapper[data-poppup-placement^="bottom"] {
       .tooltip__content {
         transform-origin: top;
       }
@@ -77,7 +77,7 @@
       }
     }
 
-    &__wrapper[data-popper-placement^="left"] {
+    &__wrapper[data-poppup-placement^="left"] {
       .tooltip__content {
         transform-origin: right;
       }
@@ -86,7 +86,7 @@
       }
     }
 
-    &__wrapper[data-popper-placement^="right"] {
+    &__wrapper[data-poppup-placement^="right"] {
       .tooltip__content {
         transform-origin: left;
       }

--- a/@utahdts/utah-design-system/css/6-components/base-components/popups/_tooltips.scss
+++ b/@utahdts/utah-design-system/css/6-components/base-components/popups/_tooltips.scss
@@ -59,7 +59,7 @@
       }
     }
 
-    &__wrapper[data-poppup-placement^="top"] {
+    &__wrapper[data-popup-placement^="top"] {
       .tooltip__content {
         transform-origin: bottom;
       }
@@ -68,7 +68,7 @@
       }
     }
 
-    &__wrapper[data-poppup-placement^="bottom"] {
+    &__wrapper[data-popup-placement^="bottom"] {
       .tooltip__content {
         transform-origin: top;
       }
@@ -77,7 +77,7 @@
       }
     }
 
-    &__wrapper[data-poppup-placement^="left"] {
+    &__wrapper[data-popup-placement^="left"] {
       .tooltip__content {
         transform-origin: right;
       }
@@ -86,7 +86,7 @@
       }
     }
 
-    &__wrapper[data-poppup-placement^="right"] {
+    &__wrapper[data-popup-placement^="right"] {
       .tooltip__content {
         transform-origin: left;
       }

--- a/@utahdts/utah-design-system/package.json
+++ b/@utahdts/utah-design-system/package.json
@@ -65,7 +65,6 @@
   },
   "homepage": "https://github.com/utahdts/utah-design-system",
   "dependencies": {
-    "@floating-ui/react-dom": "^2.1.2",
     "@utahdts/utah-design-system-header": "3.0.5",
     "date-fns": "4.1.0",
     "immer": "10.1.1",
@@ -73,6 +72,7 @@
     "prop-types": "15.8.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-popper": "2.3.0",
     "use-immer": "0.11.0",
     "uuid": "11.1.0"
   },

--- a/@utahdts/utah-design-system/package.json
+++ b/@utahdts/utah-design-system/package.json
@@ -32,9 +32,6 @@
     "dist",
     "react"
   ],
-  "peerDependencies": {
-    "react": "18.x"
-  },
   "scripts": {
     "build": "vite build",
     "buildw": "vite build --watch",
@@ -68,13 +65,14 @@
   },
   "homepage": "https://github.com/utahdts/utah-design-system",
   "dependencies": {
+    "@floating-ui/react-dom": "^2.1.2",
     "@utahdts/utah-design-system-header": "3.0.5",
     "date-fns": "4.1.0",
     "immer": "10.1.1",
     "lodash": "4.17.21",
     "prop-types": "15.8.1",
-    "react": "18.x",
-    "react-popper": "2.3.0",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
     "use-immer": "0.11.0",
     "uuid": "11.1.0"
   },

--- a/@utahdts/utah-design-system/package.json
+++ b/@utahdts/utah-design-system/package.json
@@ -2,7 +2,7 @@
   "name": "@utahdts/utah-design-system",
   "description": "Utah Design System React Library",
   "displayName": "Utah Design System React Library",
-  "version": "3.0.5",
+  "version": "4.0.0",
   "exports": {
     ".": {
       "development-local": "./index.js",
@@ -65,14 +65,14 @@
   },
   "homepage": "https://github.com/utahdts/utah-design-system",
   "dependencies": {
-    "@floating-ui/react-dom": "^2.1.2",
+    "@floating-ui/react-dom": "2.1.2",
     "@utahdts/utah-design-system-header": "3.0.5",
     "date-fns": "4.1.0",
     "immer": "10.1.1",
     "lodash": "4.17.21",
     "prop-types": "15.8.1",
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0",
+    "react": "19.1.0",
+    "react-dom": "19.1.0",
     "use-immer": "0.11.0",
     "uuid": "11.1.0"
   },

--- a/@utahdts/utah-design-system/package.json
+++ b/@utahdts/utah-design-system/package.json
@@ -65,6 +65,7 @@
   },
   "homepage": "https://github.com/utahdts/utah-design-system",
   "dependencies": {
+    "@floating-ui/react-dom": "^2.1.2",
     "@utahdts/utah-design-system-header": "3.0.5",
     "date-fns": "4.1.0",
     "immer": "10.1.1",
@@ -72,7 +73,6 @@
     "prop-types": "15.8.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-popper": "2.3.0",
     "use-immer": "0.11.0",
     "uuid": "11.1.0"
   },

--- a/@utahdts/utah-design-system/react/components/PROPTYPES.MD
+++ b/@utahdts/utah-design-system/react/components/PROPTYPES.MD
@@ -10,7 +10,7 @@ When adding a new prop, make sure it fits these guidelines and doesn't already e
 * `Boolean props`
 props that are true/false should generally start with the word `is`. ie:
   - `isDisabled`
-  - `isPoppupVisible`
+  - `isPopupVisible`
 
   There may be some props like `showChildContent` that would be awkward if they started with is `isShowChildContent` so those props should start with a verb.
 

--- a/@utahdts/utah-design-system/react/components/PROPTYPES.MD
+++ b/@utahdts/utah-design-system/react/components/PROPTYPES.MD
@@ -10,7 +10,7 @@ When adding a new prop, make sure it fits these guidelines and doesn't already e
 * `Boolean props`
 props that are true/false should generally start with the word `is`. ie:
   - `isDisabled`
-  - `isPopperVisible`
+  - `isPoppupVisible`
 
   There may be some props like `showChildContent` that would be awkward if they started with is `isShowChildContent` so those props should start with a verb.
 

--- a/@utahdts/utah-design-system/react/components/forms/ComboBox/ComboBox.jsx
+++ b/@utahdts/utah-design-system/react/components/forms/ComboBox/ComboBox.jsx
@@ -35,7 +35,7 @@ import { ComboBoxTextInput } from './internal/ComboBoxTextInput';
  * @param {(customValue: string) => void} [props.onCustomEntry] caller is responsible for adding options when they are added
  * @param {(e: Event, currentFilterValue: string) => boolean} [props.onKeyUp]
  * @param {string} [props.placeholder]
- * @param {HTMLElement | null} [props.poppupContentRef] for multi-select the popup relates to the multi-select wrapper, not the input
+ * @param {HTMLElement | null} [props.popupContentRef] for multi-select the popup relates to the multi-select wrapper, not the input
  * @param {import('react').ReactNode} [props.tagChildren]
  * @param {string} [props.textInputClassName] className to put on the TextInput
  * @param {string} [props.value]
@@ -64,7 +64,7 @@ export function ComboBox({
   onClear,
   onKeyUp,
   placeholder,
-  poppupContentRef,
+  popupContentRef,
   isValueClearedOnSelection,
   isWrapperSkipped,
   tagChildren,
@@ -107,7 +107,7 @@ export function ComboBox({
         allowCustomEntry={allowCustomEntry}
         id={comboBoxListId}
         ariaLabelledById={id}
-        poppupReferenceElement={poppupContentRef ?? contentRefState ?? null}
+        popupReferenceElement={popupContentRef ?? contentRefState ?? null}
       >
         {children}
       </CombBoxListBox>

--- a/@utahdts/utah-design-system/react/components/forms/ComboBox/ComboBox.jsx
+++ b/@utahdts/utah-design-system/react/components/forms/ComboBox/ComboBox.jsx
@@ -35,7 +35,7 @@ import { ComboBoxTextInput } from './internal/ComboBoxTextInput';
  * @param {(customValue: string) => void} [props.onCustomEntry] caller is responsible for adding options when they are added
  * @param {(e: Event, currentFilterValue: string) => boolean} [props.onKeyUp]
  * @param {string} [props.placeholder]
- * @param {HTMLElement | null} [props.popperContentRef] for multi-select the popup relates to the multi-select wrapper, not the input
+ * @param {HTMLElement | null} [props.poppupContentRef] for multi-select the popup relates to the multi-select wrapper, not the input
  * @param {import('react').ReactNode} [props.tagChildren]
  * @param {string} [props.textInputClassName] className to put on the TextInput
  * @param {string} [props.value]
@@ -64,7 +64,7 @@ export function ComboBox({
   onClear,
   onKeyUp,
   placeholder,
-  popperContentRef,
+  poppupContentRef,
   isValueClearedOnSelection,
   isWrapperSkipped,
   tagChildren,
@@ -107,7 +107,7 @@ export function ComboBox({
         allowCustomEntry={allowCustomEntry}
         id={comboBoxListId}
         ariaLabelledById={id}
-        popperReferenceElement={popperContentRef ?? contentRefState ?? null}
+        poppupReferenceElement={poppupContentRef ?? contentRefState ?? null}
       >
         {children}
       </CombBoxListBox>

--- a/@utahdts/utah-design-system/react/components/forms/ComboBox/internal/CombBoxListBox.jsx
+++ b/@utahdts/utah-design-system/react/components/forms/ComboBox/internal/CombBoxListBox.jsx
@@ -14,7 +14,7 @@ import { isOptionGroupVisible } from '../functions/isOptionGroupVisible';
  * @param {boolean} [props.allowCustomEntry] if allowing custom entry, add the custom item if the list is empty; Must be a controlled component
  * @param {string} props.ariaLabelledById
  * @param {import('react').ReactNode | null} [props.children]
- * @param {HTMLElement | null} props.popperReferenceElement
+ * @param {HTMLElement | null} props.poppupReferenceElement
  * @param {string} props.id
  * @returns {import('react').JSX.Element}
  */
@@ -23,7 +23,7 @@ export function CombBoxListBox({
   ariaLabelledById,
   children,
   id,
-  popperReferenceElement,
+  poppupReferenceElement,
 }) {
   const [{ selectedValues }] = useMultiSelectContext();
   const { addPoliteMessage } = useAriaMessaging();
@@ -44,7 +44,7 @@ export function CombBoxListBox({
 
   const { floatingStyles } = useFloating({
     elements: {
-      reference: popperReferenceElement,
+      reference: poppupReferenceElement,
       floating: ulRef.current,
     },
     middleware: [
@@ -124,7 +124,7 @@ export function CombBoxListBox({
       role="listbox"
       style={{
         ...floatingStyles,
-        minWidth: popperReferenceElement?.scrollWidth,
+        minWidth: poppupReferenceElement?.scrollWidth,
       }}
       tabIndex={-1}
     >

--- a/@utahdts/utah-design-system/react/components/forms/ComboBox/internal/CombBoxListBox.jsx
+++ b/@utahdts/utah-design-system/react/components/forms/ComboBox/internal/CombBoxListBox.jsx
@@ -14,7 +14,7 @@ import { isOptionGroupVisible } from '../functions/isOptionGroupVisible';
  * @param {boolean} [props.allowCustomEntry] if allowing custom entry, add the custom item if the list is empty; Must be a controlled component
  * @param {string} props.ariaLabelledById
  * @param {import('react').ReactNode | null} [props.children]
- * @param {HTMLElement | null} props.poppupReferenceElement
+ * @param {HTMLElement | null} props.popupReferenceElement
  * @param {string} props.id
  * @returns {import('react').JSX.Element}
  */
@@ -23,7 +23,7 @@ export function CombBoxListBox({
   ariaLabelledById,
   children,
   id,
-  poppupReferenceElement,
+  popupReferenceElement,
 }) {
   const [{ selectedValues }] = useMultiSelectContext();
   const { addPoliteMessage } = useAriaMessaging();
@@ -44,7 +44,7 @@ export function CombBoxListBox({
 
   const { floatingStyles } = useFloating({
     elements: {
-      reference: poppupReferenceElement,
+      reference: popupReferenceElement,
       floating: ulRef.current,
     },
     middleware: [
@@ -124,7 +124,7 @@ export function CombBoxListBox({
       role="listbox"
       style={{
         ...floatingStyles,
-        minWidth: poppupReferenceElement?.scrollWidth,
+        minWidth: popupReferenceElement?.scrollWidth,
       }}
       tabIndex={-1}
     >

--- a/@utahdts/utah-design-system/react/components/forms/ComboBox/internal/CombBoxListBox.jsx
+++ b/@utahdts/utah-design-system/react/components/forms/ComboBox/internal/CombBoxListBox.jsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef } from 'react';
-import { useFloating, autoUpdate, offset, shift, flip } from '@floating-ui/react-dom';
+import { useFloating, autoUpdate, offset as floatingOffset, shift, flip } from '@floating-ui/react-dom';
 import { useAriaMessaging } from '../../../../contexts/UtahDesignSystemContext/hooks/useAriaMessaging';
 import { popupPlacement } from '../../../../enums/popupPlacement';
 import { useDebounceFunc } from '../../../../hooks/useDebounceFunc';
@@ -48,7 +48,7 @@ export function CombBoxListBox({
       floating: ulRef.current,
     },
     middleware: [
-      offset({mainAxis: 4, crossAxis: 0, alignmentAxis: 0}),
+      floatingOffset({mainAxis: 4, crossAxis: 0, alignmentAxis: 0}),
       flip(),
       shift(),
     ],

--- a/@utahdts/utah-design-system/react/components/forms/ComboBox/internal/CombBoxListBox.jsx
+++ b/@utahdts/utah-design-system/react/components/forms/ComboBox/internal/CombBoxListBox.jsx
@@ -48,7 +48,7 @@ export function CombBoxListBox({
       floating: ulRef.current,
     },
     middleware: [
-      offset(4),
+      offset({mainAxis: 4, crossAxis: 0, alignmentAxis: 0}),
       flip(),
       shift(),
     ],

--- a/@utahdts/utah-design-system/react/components/forms/ComboBox/internal/CombBoxListBox.jsx
+++ b/@utahdts/utah-design-system/react/components/forms/ComboBox/internal/CombBoxListBox.jsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef } from 'react';
-import { usePopper } from 'react-popper';
+import { useFloating, autoUpdate, offset, shift, flip } from '@floating-ui/react-dom';
 import { useAriaMessaging } from '../../../../contexts/UtahDesignSystemContext/hooks/useAriaMessaging';
 import { popupPlacement } from '../../../../enums/popupPlacement';
 import { useDebounceFunc } from '../../../../hooks/useDebounceFunc';
@@ -42,16 +42,20 @@ export function CombBoxListBox({
   const ulRef = useRef(/** @type {HTMLUListElement | null} */(null));
   const announcedArrowKeysRef = useRef(false);
 
-  const { styles, attributes, update } = usePopper(
-    popperReferenceElement,
-    ulRef.current,
-    {
-      placement: popupPlacement.BOTTOM,
-      modifiers: [
-        { name: 'offset', options: { offset: [0, 4] } },
-      ],
-    }
-  );
+  const { floatingStyles } = useFloating({
+    elements: {
+      reference: popperReferenceElement,
+      floating: ulRef.current,
+    },
+    middleware: [
+      offset(4),
+      flip(),
+      shift(),
+    ],
+    open: isOptionsExpanded,
+    placement: popupPlacement.BOTTOM,
+    whileElementsMounted: autoUpdate,
+  });
 
   const lastMessageRef = useRef(/** @type {string | null} */(null));
   const addPoliteMessageDebounced = useDebounceFunc(
@@ -65,15 +69,6 @@ export function CombBoxListBox({
       [addPoliteMessage]
     ),
     1500
-  );
-
-  useEffect(
-    () => {
-      if (update) {
-        update();
-      }
-    },
-    [isOptionsExpanded, selectedValues, update]
   );
 
   useEffect(
@@ -128,11 +123,10 @@ export function CombBoxListBox({
       ref={ulRef}
       role="listbox"
       style={{
-        ...styles.popper,
+        ...floatingStyles,
         minWidth: popperReferenceElement?.scrollWidth,
       }}
       tabIndex={-1}
-      {...attributes.popper}
     >
       {children}
       {

--- a/@utahdts/utah-design-system/react/components/forms/DateInput.jsx
+++ b/@utahdts/utah-design-system/react/components/forms/DateInput.jsx
@@ -76,7 +76,7 @@ export function DateInput({
       floating: calendarRef.current,
     },
     middleware: [
-      offset(4),
+      offset({mainAxis: 4, crossAxis: 0, alignmentAxis: 0}),
       flip(),
       shift(),
     ],

--- a/@utahdts/utah-design-system/react/components/forms/DateInput.jsx
+++ b/@utahdts/utah-design-system/react/components/forms/DateInput.jsx
@@ -68,11 +68,11 @@ export function DateInput({
 }) {
   const wrapperInternalRef = useRef(/** @type {HTMLDivElement | null} */(null));
   const [isCalendarPopupOpen, setIsCalendarPopupOpen] = useImmer(false);
-  const poppupReferenceElementRef = useRef(/** @type {HTMLDivElement | null} */(null));
+  const popupReferenceElementRef = useRef(/** @type {HTMLDivElement | null} */(null));
   const calendarRef = useRef(/** @type {HTMLDivElement | null} */(null));
   const { floatingStyles } = useFloating({
     elements: {
-      reference: poppupReferenceElementRef.current,
+      reference: popupReferenceElementRef.current,
       floating: calendarRef.current,
     },
     middleware: [
@@ -124,7 +124,7 @@ export function DateInput({
             defaultValue={defaultValue}
             errorMessage={errorMessage}
             id={id}
-            innerRef={poppupReferenceElementRef}
+            innerRef={popupReferenceElementRef}
             isClearable={isClearable}
             isDisabled={isDisabled}
             isRequired={isRequired}
@@ -151,7 +151,7 @@ export function DateInput({
                       e.stopPropagation();
                       setIsCalendarPopupOpen((isOpen) => {
                         if (isOpen) {
-                          const textInput = poppupReferenceElementRef.current?.querySelector('input[type="text"]');
+                          const textInput = popupReferenceElementRef.current?.querySelector('input[type="text"]');
                           // @ts-expect-error
                           textInput?.focus();
                         }
@@ -172,7 +172,7 @@ export function DateInput({
                     onMouseDown={(e) => {
                       // without the preventDefault, clicking the calendar was closing the popup instead of focusing in the text input
                       e.preventDefault();
-                      poppupReferenceElementRef.current?.querySelector('input')?.focus();
+                      popupReferenceElementRef.current?.querySelector('input')?.focus();
                     }}
                   >
                     <span className="utds-icon-before-calendar " aria-hidden="true" />
@@ -205,7 +205,7 @@ export function DateInput({
                 ref={calendarRef}
                 style={{
                   ...floatingStyles,
-                  minWidth: poppupReferenceElementRef.current?.offsetWidth,
+                  minWidth: popupReferenceElementRef.current?.offsetWidth,
                 }}
               >
                 <CalendarInput
@@ -217,7 +217,7 @@ export function DateInput({
                   onChange={(newValue) => {
                     onChange?.(newValue);
                     setIsCalendarPopupOpen(false);
-                    const textInput = poppupReferenceElementRef.current?.querySelector('input[type="text"]');
+                    const textInput = popupReferenceElementRef.current?.querySelector('input[type="text"]');
                     // @ts-expect-error
                     textInput?.focus();
                   }}

--- a/@utahdts/utah-design-system/react/components/forms/DateInput.jsx
+++ b/@utahdts/utah-design-system/react/components/forms/DateInput.jsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useRef } from 'react';
-import { usePopper } from 'react-popper';
+import { useCallback, useRef } from 'react';
+import { useFloating, autoUpdate, offset, shift, flip } from '@floating-ui/react-dom';
 import { useImmer } from 'use-immer';
 import { popupPlacement } from '../../enums/popupPlacement';
 import { useInterval } from '../../hooks/useInterval';
@@ -70,25 +70,20 @@ export function DateInput({
   const [isCalendarPopupOpen, setIsCalendarPopupOpen] = useImmer(false);
   const popperReferenceElementRef = useRef(/** @type {HTMLDivElement | null} */(null));
   const calendarRef = useRef(/** @type {HTMLDivElement | null} */(null));
-  const { styles, attributes, update } = usePopper(
-    popperReferenceElementRef.current,
-    calendarRef.current,
-    {
-      placement: popupPlacement.BOTTOM,
-      modifiers: [
-        { name: 'offset', options: { offset: [0, 4] } },
-      ],
-    }
-  );
-  // update popper location on changes
-  useEffect(
-    () => {
-      if (update) {
-        update();
-      }
+  const { floatingStyles } = useFloating({
+    elements: {
+      reference: popperReferenceElementRef.current,
+      floating: calendarRef.current,
     },
-    [isCalendarPopupOpen, value, update]
-  );
+    middleware: [
+      offset(4),
+      flip(),
+      shift(),
+    ],
+    open: isCalendarPopupOpen,
+    placement: popupPlacement.BOTTOM,
+    whileElementsMounted: autoUpdate,
+  });
 
   // check if no longer have focus when open
   useInterval(
@@ -209,10 +204,9 @@ export function DateInput({
                 className={joinClassNames('date-input__popup', isCalendarPopupOpen ? '' : 'visually-hidden')}
                 ref={calendarRef}
                 style={{
-                  ...styles.popper,
+                  ...floatingStyles,
                   minWidth: popperReferenceElementRef.current?.offsetWidth,
                 }}
-                {...attributes.popper}
               >
                 <CalendarInput
                   dateFormat={dateFormat}

--- a/@utahdts/utah-design-system/react/components/forms/DateInput.jsx
+++ b/@utahdts/utah-design-system/react/components/forms/DateInput.jsx
@@ -68,11 +68,11 @@ export function DateInput({
 }) {
   const wrapperInternalRef = useRef(/** @type {HTMLDivElement | null} */(null));
   const [isCalendarPopupOpen, setIsCalendarPopupOpen] = useImmer(false);
-  const popperReferenceElementRef = useRef(/** @type {HTMLDivElement | null} */(null));
+  const poppupReferenceElementRef = useRef(/** @type {HTMLDivElement | null} */(null));
   const calendarRef = useRef(/** @type {HTMLDivElement | null} */(null));
   const { floatingStyles } = useFloating({
     elements: {
-      reference: popperReferenceElementRef.current,
+      reference: poppupReferenceElementRef.current,
       floating: calendarRef.current,
     },
     middleware: [
@@ -124,7 +124,7 @@ export function DateInput({
             defaultValue={defaultValue}
             errorMessage={errorMessage}
             id={id}
-            innerRef={popperReferenceElementRef}
+            innerRef={poppupReferenceElementRef}
             isClearable={isClearable}
             isDisabled={isDisabled}
             isRequired={isRequired}
@@ -151,7 +151,7 @@ export function DateInput({
                       e.stopPropagation();
                       setIsCalendarPopupOpen((isOpen) => {
                         if (isOpen) {
-                          const textInput = popperReferenceElementRef.current?.querySelector('input[type="text"]');
+                          const textInput = poppupReferenceElementRef.current?.querySelector('input[type="text"]');
                           // @ts-expect-error
                           textInput?.focus();
                         }
@@ -172,7 +172,7 @@ export function DateInput({
                     onMouseDown={(e) => {
                       // without the preventDefault, clicking the calendar was closing the popup instead of focusing in the text input
                       e.preventDefault();
-                      popperReferenceElementRef.current?.querySelector('input')?.focus();
+                      poppupReferenceElementRef.current?.querySelector('input')?.focus();
                     }}
                   >
                     <span className="utds-icon-before-calendar " aria-hidden="true" />
@@ -205,7 +205,7 @@ export function DateInput({
                 ref={calendarRef}
                 style={{
                   ...floatingStyles,
-                  minWidth: popperReferenceElementRef.current?.offsetWidth,
+                  minWidth: poppupReferenceElementRef.current?.offsetWidth,
                 }}
               >
                 <CalendarInput
@@ -217,7 +217,7 @@ export function DateInput({
                   onChange={(newValue) => {
                     onChange?.(newValue);
                     setIsCalendarPopupOpen(false);
-                    const textInput = popperReferenceElementRef.current?.querySelector('input[type="text"]');
+                    const textInput = poppupReferenceElementRef.current?.querySelector('input[type="text"]');
                     // @ts-expect-error
                     textInput?.focus();
                   }}

--- a/@utahdts/utah-design-system/react/components/forms/DateInput.jsx
+++ b/@utahdts/utah-design-system/react/components/forms/DateInput.jsx
@@ -1,5 +1,5 @@
 import { useCallback, useRef } from 'react';
-import { useFloating, autoUpdate, offset, shift, flip } from '@floating-ui/react-dom';
+import { useFloating, autoUpdate, offset as floatingOffset, shift, flip } from '@floating-ui/react-dom';
 import { useImmer } from 'use-immer';
 import { popupPlacement } from '../../enums/popupPlacement';
 import { useInterval } from '../../hooks/useInterval';
@@ -76,7 +76,7 @@ export function DateInput({
       floating: calendarRef.current,
     },
     middleware: [
-      offset({mainAxis: 4, crossAxis: 0, alignmentAxis: 0}),
+      floatingOffset({mainAxis: 4, crossAxis: 0, alignmentAxis: 0}),
       flip(),
       shift(),
     ],

--- a/@utahdts/utah-design-system/react/components/forms/MultiSelect/MultiSelectComboBox.jsx
+++ b/@utahdts/utah-design-system/react/components/forms/MultiSelect/MultiSelectComboBox.jsx
@@ -164,7 +164,7 @@ export function MultiSelectComboBox({
               return eventIsHandled;
             }}
             placeholder={placeholder}
-            poppupContentRef={multiSelectContextNonStateRef?.current.comboBoxDivElement}
+            popupContentRef={multiSelectContextNonStateRef?.current.comboBoxDivElement}
             // the value is always unset because the multi-select will own and show the current value
             value=""
             wrapperClassName={wrapperClassName}
@@ -222,7 +222,7 @@ export function MultiSelectComboBox({
             title="Toggle popup menu"
             // @ts-expect-error
             onBlur={() => {
-              // tabbing off of toggle icon while the poppup options list was open was not closing the list
+              // tabbing off of toggle icon while the popup options list was open was not closing the list
               // because the list didn't get focus when it was opened by a click
               setTimeout(
                 () => {

--- a/@utahdts/utah-design-system/react/components/forms/MultiSelect/MultiSelectComboBox.jsx
+++ b/@utahdts/utah-design-system/react/components/forms/MultiSelect/MultiSelectComboBox.jsx
@@ -164,7 +164,7 @@ export function MultiSelectComboBox({
               return eventIsHandled;
             }}
             placeholder={placeholder}
-            popperContentRef={multiSelectContextNonStateRef?.current.comboBoxDivElement}
+            poppupContentRef={multiSelectContextNonStateRef?.current.comboBoxDivElement}
             // the value is always unset because the multi-select will own and show the current value
             value=""
             wrapperClassName={wrapperClassName}
@@ -222,7 +222,7 @@ export function MultiSelectComboBox({
             title="Toggle popup menu"
             // @ts-expect-error
             onBlur={() => {
-              // tabbing off of toggle icon while the popper options list was open was not closing the list
+              // tabbing off of toggle icon while the poppup options list was open was not closing the list
               // because the list didn't get focus when it was opened by a click
               setTimeout(
                 () => {

--- a/@utahdts/utah-design-system/react/components/navigation/items/MenuItemFlyout.jsx
+++ b/@utahdts/utah-design-system/react/components/navigation/items/MenuItemFlyout.jsx
@@ -1,6 +1,6 @@
 import { popupFocusHandler } from '@utahdts/utah-design-system-header';
 import { useEffect, useRef } from 'react';
-import { usePopper } from 'react-popper';
+import { autoUpdate, flip, offset, shift, useFloating } from '@floating-ui/react-dom';
 import { useImmer } from 'use-immer';
 import { ICON_BUTTON_APPEARANCE } from '../../../enums/buttonEnums';
 import { menuTypes } from '../../../enums/menuTypes';
@@ -32,7 +32,21 @@ export function MenuItemFlyout({
   const wrapperElement = useRef(/** @type {HTMLLIElement | null} */(null));
   const buttonRef = useRef(/** @type {HTMLButtonElement | null} */(null));
   const popperRef = useRef(/** @type {HTMLDivElement | null} */(null));
-  const { styles, attributes } = usePopper(wrapperElement.current, popperRef.current, { placement: 'right-start' });
+
+  const { floatingStyles } = useFloating({
+    elements: {
+      reference: buttonRef.current,
+      floating: popperRef.current,
+    },
+    open: isChildrenOpen,
+    placement: 'right-start',
+    middleware: [
+      offset(10),
+      flip(),
+      shift(),
+    ],
+    whileElementsMounted: autoUpdate,
+  });
 
   useClickOutside([popperRef], () => setIsChildrenOpen(false), !isChildrenOpen);
 
@@ -59,7 +73,7 @@ export function MenuItemFlyout({
         }
       );
     }
-  }, [triggerOnHover, buttonRef, popperRef, buttonRef]);
+  }, [triggerOnHover, buttonRef, popperRef]);
 
   return (
     <li className={menuType === menuTypes.VERTICAL ? 'vertical-menu__item' : 'menu-item'} ref={wrapperElement}>
@@ -121,8 +135,7 @@ export function MenuItemFlyout({
               )}
               id={`menu-item__${menuItem.id}__${menuItem.link || 'link'}-popup`}
               ref={popperRef}
-              style={styles.popper}
-              {...attributes.popper}
+              style={floatingStyles}
             >
               <div className="popup__content flyout-menu">
                 <ul className={menuType === menuTypes.VERTICAL ? 'vertical-menu' : ''}>

--- a/@utahdts/utah-design-system/react/components/navigation/items/MenuItemFlyout.jsx
+++ b/@utahdts/utah-design-system/react/components/navigation/items/MenuItemFlyout.jsx
@@ -31,12 +31,12 @@ export function MenuItemFlyout({
   const [isChildrenOpen, setIsChildrenOpen] = useImmer(false);
   const wrapperElement = useRef(/** @type {HTMLLIElement | null} */(null));
   const buttonRef = useRef(/** @type {HTMLButtonElement | null} */(null));
-  const popperRef = useRef(/** @type {HTMLDivElement | null} */(null));
+  const poppupRef = useRef(/** @type {HTMLDivElement | null} */(null));
 
   const { floatingStyles } = useFloating({
     elements: {
       reference: buttonRef.current,
-      floating: popperRef.current,
+      floating: poppupRef.current,
     },
     open: isChildrenOpen,
     placement: 'right-start',
@@ -48,7 +48,7 @@ export function MenuItemFlyout({
     whileElementsMounted: autoUpdate,
   });
 
-  useClickOutside([popperRef], () => setIsChildrenOpen(false), !isChildrenOpen);
+  useClickOutside([poppupRef], () => setIsChildrenOpen(false), !isChildrenOpen);
 
   const isExpanded = () => {
     let retVal;
@@ -59,12 +59,12 @@ export function MenuItemFlyout({
   };
 
   useEffect(() => {
-    if (triggerOnHover && buttonRef?.current && popperRef?.current && !buttonRef?.current.onclick) {
+    if (triggerOnHover && buttonRef?.current && poppupRef?.current && !buttonRef?.current.onclick) {
       popupFocusHandler(
         // @ts-expect-error
         wrapperElement.current,
         buttonRef.current,
-        popperRef.current,
+        poppupRef.current,
         'menu',
         {
           shouldFocusOnHover: true,
@@ -73,7 +73,7 @@ export function MenuItemFlyout({
         }
       );
     }
-  }, [triggerOnHover, buttonRef, popperRef]);
+  }, [triggerOnHover, buttonRef, poppupRef]);
 
   return (
     <li className={menuType === menuTypes.VERTICAL ? 'vertical-menu__item' : 'menu-item'} ref={wrapperElement}>
@@ -134,7 +134,7 @@ export function MenuItemFlyout({
                 isChildrenOpen ? 'popup__wrapper--visible' : 'popup__wrapper--hidden'
               )}
               id={`menu-item__${menuItem.id}__${menuItem.link || 'link'}-popup`}
-              ref={popperRef}
+              ref={poppupRef}
               style={floatingStyles}
             >
               <div className="popup__content flyout-menu">

--- a/@utahdts/utah-design-system/react/components/navigation/items/MenuItemFlyout.jsx
+++ b/@utahdts/utah-design-system/react/components/navigation/items/MenuItemFlyout.jsx
@@ -1,6 +1,6 @@
 import { popupFocusHandler } from '@utahdts/utah-design-system-header';
 import { useEffect, useRef } from 'react';
-import { autoUpdate, flip, offset, shift, useFloating } from '@floating-ui/react-dom';
+import { autoUpdate, flip, offset as floatingOffset, shift, useFloating } from '@floating-ui/react-dom';
 import { useImmer } from 'use-immer';
 import { ICON_BUTTON_APPEARANCE } from '../../../enums/buttonEnums';
 import { menuTypes } from '../../../enums/menuTypes';
@@ -41,7 +41,7 @@ export function MenuItemFlyout({
     open: isChildrenOpen,
     placement: 'right-start',
     middleware: [
-      offset(10),
+      floatingOffset(10),
       flip(),
       shift(),
     ],

--- a/@utahdts/utah-design-system/react/components/navigation/items/MenuItemFlyout.jsx
+++ b/@utahdts/utah-design-system/react/components/navigation/items/MenuItemFlyout.jsx
@@ -31,12 +31,12 @@ export function MenuItemFlyout({
   const [isChildrenOpen, setIsChildrenOpen] = useImmer(false);
   const wrapperElement = useRef(/** @type {HTMLLIElement | null} */(null));
   const buttonRef = useRef(/** @type {HTMLButtonElement | null} */(null));
-  const poppupRef = useRef(/** @type {HTMLDivElement | null} */(null));
+  const popupRef = useRef(/** @type {HTMLDivElement | null} */(null));
 
   const { floatingStyles } = useFloating({
     elements: {
       reference: buttonRef.current,
-      floating: poppupRef.current,
+      floating: popupRef.current,
     },
     open: isChildrenOpen,
     placement: 'right-start',
@@ -48,7 +48,7 @@ export function MenuItemFlyout({
     whileElementsMounted: autoUpdate,
   });
 
-  useClickOutside([poppupRef], () => setIsChildrenOpen(false), !isChildrenOpen);
+  useClickOutside([popupRef], () => setIsChildrenOpen(false), !isChildrenOpen);
 
   const isExpanded = () => {
     let retVal;
@@ -59,12 +59,12 @@ export function MenuItemFlyout({
   };
 
   useEffect(() => {
-    if (triggerOnHover && buttonRef?.current && poppupRef?.current && !buttonRef?.current.onclick) {
+    if (triggerOnHover && buttonRef?.current && popupRef?.current && !buttonRef?.current.onclick) {
       popupFocusHandler(
         // @ts-expect-error
         wrapperElement.current,
         buttonRef.current,
-        poppupRef.current,
+        popupRef.current,
         'menu',
         {
           shouldFocusOnHover: true,
@@ -73,7 +73,7 @@ export function MenuItemFlyout({
         }
       );
     }
-  }, [triggerOnHover, buttonRef, poppupRef]);
+  }, [triggerOnHover, buttonRef, popupRef]);
 
   return (
     <li className={menuType === menuTypes.VERTICAL ? 'vertical-menu__item' : 'menu-item'} ref={wrapperElement}>
@@ -134,7 +134,7 @@ export function MenuItemFlyout({
                 isChildrenOpen ? 'popup__wrapper--visible' : 'popup__wrapper--hidden'
               )}
               id={`menu-item__${menuItem.id}__${menuItem.link || 'link'}-popup`}
-              ref={poppupRef}
+              ref={popupRef}
               style={floatingStyles}
             >
               <div className="popup__content flyout-menu">

--- a/@utahdts/utah-design-system/react/components/popups/Popup.jsx
+++ b/@utahdts/utah-design-system/react/components/popups/Popup.jsx
@@ -18,7 +18,7 @@ import { IconButton } from '../buttons/IconButton';
  * @param {string} props.id used for hooking up to the button that controls the popup by aria-control
  * @param {import('react').MutableRefObject<HTMLDivElement | null>} [props.innerRef] ref to the popup wrapper
  * @param {boolean} props.isVisible Control the visibility of the popup
- * @param {number | {mainAxis: number, crossAxis: number, alignmentAxis: number}} [props.offsetProp] [x, y] offset of popped content from
+ * @param {number | {mainAxis: number, crossAxis: number, alignmentAxis: number}} [props.position] [x, y] offset of popped content from
  * @param {(e: React.UIEvent, isVisible: boolean) => void} props.onVisibleChange popup closed; (e, newVisibility) => { ... do something ... }
  * @param {PopupPlacement} [props.placement] The Popper Placement
  * @param {import('react').RefObject<HTMLElement | null>} props.referenceElement the anchor element around which the popup content will pop
@@ -33,7 +33,7 @@ export function Popup({
   id,
   innerRef: draftInnerRef,
   isVisible,
-  offsetProp = 10,
+  position = 10,
   onVisibleChange,
   placement = popupPlacement.BOTTOM,
   referenceElement,
@@ -54,7 +54,7 @@ export function Popup({
       floating: popperRef.current,
     },
     middleware: [
-      offset(offsetProp),
+      offset(position),
       flip(),
       shift(),
       arrow({

--- a/@utahdts/utah-design-system/react/components/popups/Popup.jsx
+++ b/@utahdts/utah-design-system/react/components/popups/Popup.jsx
@@ -33,7 +33,7 @@ export function Popup({
   id,
   innerRef: draftInnerRef,
   isVisible,
-  position = 10,
+  position = {mainAxis: 10, crossAxis: 0, alignmentAxis: 0},
   onVisibleChange,
   placement = popupPlacement.BOTTOM,
   referenceElement,

--- a/@utahdts/utah-design-system/react/components/popups/Popup.jsx
+++ b/@utahdts/utah-design-system/react/components/popups/Popup.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useRef } from 'react';
-import { useFloating, autoUpdate, offset, shift, flip, arrow } from '@floating-ui/react-dom';
+import { useFloating, autoUpdate, offset as floatingOffset, shift, flip, arrow } from '@floating-ui/react-dom';
 import { ICON_BUTTON_APPEARANCE } from '../../enums/buttonEnums';
 import { popupPlacement } from '../../enums/popupPlacement';
 import { useClickOutside } from '../../hooks/useClickOutside';
@@ -18,7 +18,7 @@ import { IconButton } from '../buttons/IconButton';
  * @param {string} props.id used for hooking up to the button that controls the popup by aria-control
  * @param {import('react').MutableRefObject<HTMLDivElement | null>} [props.innerRef] ref to the popup wrapper
  * @param {boolean} props.isVisible Control the visibility of the popup
- * @param {number | {mainAxis: number, crossAxis: number, alignmentAxis: number}} [props.position] [x, y] offset of popped content from
+ * @param {number | {mainAxis: number, crossAxis: number, alignmentAxis?: number}} [props.offset] offset of popped content from
  * @param {(e: React.UIEvent, isVisible: boolean) => void} props.onVisibleChange popup closed; (e, newVisibility) => { ... do something ... }
  * @param {PopupPlacement} [props.placement] The Popup Placement
  * @param {import('react').RefObject<HTMLElement | null>} props.referenceElement the anchor element around which the popup content will pop
@@ -33,7 +33,7 @@ export function Popup({
   id,
   innerRef: draftInnerRef,
   isVisible,
-  position = {mainAxis: 10, crossAxis: 0, alignmentAxis: 0},
+  offset = {mainAxis: 10, crossAxis: 0},
   onVisibleChange,
   placement = popupPlacement.BOTTOM,
   referenceElement,
@@ -54,7 +54,7 @@ export function Popup({
       floating: popupRef.current,
     },
     middleware: [
-      offset(position),
+      floatingOffset(offset),
       flip(),
       shift(),
       arrow({

--- a/@utahdts/utah-design-system/react/components/popups/Popup.jsx
+++ b/@utahdts/utah-design-system/react/components/popups/Popup.jsx
@@ -20,7 +20,7 @@ import { IconButton } from '../buttons/IconButton';
  * @param {boolean} props.isVisible Control the visibility of the popup
  * @param {number | {mainAxis: number, crossAxis: number, alignmentAxis: number}} [props.position] [x, y] offset of popped content from
  * @param {(e: React.UIEvent, isVisible: boolean) => void} props.onVisibleChange popup closed; (e, newVisibility) => { ... do something ... }
- * @param {PopupPlacement} [props.placement] The Poppup Placement
+ * @param {PopupPlacement} [props.placement] The Popup Placement
  * @param {import('react').RefObject<HTMLElement | null>} props.referenceElement the anchor element around which the popup content will pop
  * @param {'dialog' | 'grid' | 'listbox' | 'menu' | 'tree'} props.role popup must tell its role for accessibility
  * @returns {import('react').JSX.Element}
@@ -40,18 +40,18 @@ export function Popup({
   role,
   ...rest
 }) {
-  const poppupRef = useRef(/** @type {HTMLDivElement | null} */(null));
+  const popupRef = useRef(/** @type {HTMLDivElement | null} */(null));
   const arrowRef = useRef(/** @type {HTMLDivElement | null} */(null));
 
   if (draftInnerRef) {
     // eslint-disable-next-line no-param-reassign
-    draftInnerRef.current = poppupRef.current;
+    draftInnerRef.current = popupRef.current;
   }
 
   const { floatingStyles, middlewareData } = useFloating({
     elements: {
       reference: referenceElement.current,
-      floating: poppupRef.current,
+      floating: popupRef.current,
     },
     middleware: [
       offset(position),
@@ -77,13 +77,13 @@ export function Popup({
     [onVisibleChange]
   );
 
-  useClickOutside([poppupRef, referenceElement], onVisibleChangeCallback, !isVisible);
+  useClickOutside([popupRef, referenceElement], onVisibleChangeCallback, !isVisible);
 
   return (
     <div
       aria-labelledby={ariaLabelledBy}
       id={id}
-      ref={poppupRef}
+      ref={popupRef}
       style={floatingStyles}
       className={joinClassNames(
         'popup__wrapper',
@@ -92,7 +92,7 @@ export function Popup({
         isVisible ? 'popup__wrapper--visible' : 'popup__wrapper--hidden'
       )}
       role={role}
-      data-poppup-placement={placement}
+      data-popup-placement={placement}
       {...rest}
     >
       <div className="popup__content">

--- a/@utahdts/utah-design-system/react/components/popups/Popup.jsx
+++ b/@utahdts/utah-design-system/react/components/popups/Popup.jsx
@@ -20,7 +20,7 @@ import { IconButton } from '../buttons/IconButton';
  * @param {boolean} props.isVisible Control the visibility of the popup
  * @param {number | {mainAxis: number, crossAxis: number, alignmentAxis: number}} [props.position] [x, y] offset of popped content from
  * @param {(e: React.UIEvent, isVisible: boolean) => void} props.onVisibleChange popup closed; (e, newVisibility) => { ... do something ... }
- * @param {PopupPlacement} [props.placement] The Popper Placement
+ * @param {PopupPlacement} [props.placement] The Poppup Placement
  * @param {import('react').RefObject<HTMLElement | null>} props.referenceElement the anchor element around which the popup content will pop
  * @param {'dialog' | 'grid' | 'listbox' | 'menu' | 'tree'} props.role popup must tell its role for accessibility
  * @returns {import('react').JSX.Element}
@@ -40,18 +40,18 @@ export function Popup({
   role,
   ...rest
 }) {
-  const popperRef = useRef(/** @type {HTMLDivElement | null} */(null));
+  const poppupRef = useRef(/** @type {HTMLDivElement | null} */(null));
   const arrowRef = useRef(/** @type {HTMLDivElement | null} */(null));
 
   if (draftInnerRef) {
     // eslint-disable-next-line no-param-reassign
-    draftInnerRef.current = popperRef.current;
+    draftInnerRef.current = poppupRef.current;
   }
 
   const { floatingStyles, middlewareData } = useFloating({
     elements: {
       reference: referenceElement.current,
-      floating: popperRef.current,
+      floating: poppupRef.current,
     },
     middleware: [
       offset(position),
@@ -77,13 +77,13 @@ export function Popup({
     [onVisibleChange]
   );
 
-  useClickOutside([popperRef, referenceElement], onVisibleChangeCallback, !isVisible);
+  useClickOutside([poppupRef, referenceElement], onVisibleChangeCallback, !isVisible);
 
   return (
     <div
       aria-labelledby={ariaLabelledBy}
       id={id}
-      ref={popperRef}
+      ref={poppupRef}
       style={floatingStyles}
       className={joinClassNames(
         'popup__wrapper',
@@ -92,7 +92,7 @@ export function Popup({
         isVisible ? 'popup__wrapper--visible' : 'popup__wrapper--hidden'
       )}
       role={role}
-      data-popper-placement={placement}
+      data-poppup-placement={placement}
       {...rest}
     >
       <div className="popup__content">

--- a/@utahdts/utah-design-system/react/components/popups/Popup.jsx
+++ b/@utahdts/utah-design-system/react/components/popups/Popup.jsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useEffect, useRef } from 'react';
-import { usePopper } from 'react-popper';
+import React, { useCallback, useRef } from 'react';
+import { useFloating, autoUpdate, offset, shift, flip, arrow } from '@floating-ui/react-dom';
 import { ICON_BUTTON_APPEARANCE } from '../../enums/buttonEnums';
 import { popupPlacement } from '../../enums/popupPlacement';
 import { useClickOutside } from '../../hooks/useClickOutside';
@@ -18,10 +18,9 @@ import { IconButton } from '../buttons/IconButton';
  * @param {string} props.id used for hooking up to the button that controls the popup by aria-control
  * @param {import('react').MutableRefObject<HTMLDivElement | null>} [props.innerRef] ref to the popup wrapper
  * @param {boolean} props.isVisible Control the visibility of the popup
- * @param {[number, number]} [props.offset] [x, y] offset of popped content from
+ * @param {number | {mainAxis: number, crossAxis: number, alignmentAxis: number}} [props.offsetProp] [x, y] offset of popped content from
  * @param {(e: React.UIEvent, isVisible: boolean) => void} props.onVisibleChange popup closed; (e, newVisibility) => { ... do something ... }
  * @param {PopupPlacement} [props.placement] The Popper Placement
- * @param {any[]} [props.popperUpdateDependencies] useEffect dependencies for updating popper placement
  * @param {import('react').RefObject<HTMLElement | null>} props.referenceElement the anchor element around which the popup content will pop
  * @param {'dialog' | 'grid' | 'listbox' | 'menu' | 'tree'} props.role popup must tell its role for accessibility
  * @returns {import('react').JSX.Element}
@@ -34,10 +33,9 @@ export function Popup({
   id,
   innerRef: draftInnerRef,
   isVisible,
-  offset = [0, 10],
+  offsetProp = 10,
   onVisibleChange,
-  placement = popupPlacement.AUTO,
-  popperUpdateDependencies,
+  placement = popupPlacement.BOTTOM,
   referenceElement,
   role,
   ...rest
@@ -50,29 +48,23 @@ export function Popup({
     draftInnerRef.current = popperRef.current;
   }
 
-  const { styles, attributes, update } = usePopper(referenceElement.current, popperRef.current, {
-    placement,
-    modifiers: [
-      {
-        name: 'arrow',
-        options: { element: arrowRef.current },
-      },
-      {
-        name: 'offset',
-        options: { offset },
-      },
-    ],
-  });
-
-  useEffect(
-    () => {
-      if (update) {
-        // eslint-disable-next-line no-console
-        update().catch((e) => console.error(e));
-      }
+  const { floatingStyles, middlewareData } = useFloating({
+    elements: {
+      reference: referenceElement.current,
+      floating: popperRef.current,
     },
-    [isVisible, update, ...(popperUpdateDependencies || [])]
-  );
+    middleware: [
+      offset(offsetProp),
+      flip(),
+      shift(),
+      arrow({
+        element: arrowRef.current,
+      }),
+    ],
+    open: isVisible,
+    placement,
+    whileElementsMounted: autoUpdate,
+  });
 
   useGlobalKeyEvent({
     whichKeyCode: 'Escape',
@@ -92,8 +84,7 @@ export function Popup({
       aria-labelledby={ariaLabelledBy}
       id={id}
       ref={popperRef}
-      style={styles.popper}
-      {...attributes.popper}
+      style={floatingStyles}
       className={joinClassNames(
         'popup__wrapper',
         className,
@@ -101,6 +92,7 @@ export function Popup({
         isVisible ? 'popup__wrapper--visible' : 'popup__wrapper--hidden'
       )}
       role={role}
+      data-popper-placement={placement}
       {...rest}
     >
       <div className="popup__content">
@@ -119,7 +111,7 @@ export function Popup({
             : undefined
         }
         {children}
-        <div ref={arrowRef} style={styles.arrow} className="popup__arrow" />
+        <div ref={arrowRef} style={{left: middlewareData.arrow?.x, top: middlewareData.arrow?.y}} className="popup__arrow" />
       </div>
     </div>
   );

--- a/@utahdts/utah-design-system/react/components/table/TableFilterDateRange.jsx
+++ b/@utahdts/utah-design-system/react/components/table/TableFilterDateRange.jsx
@@ -40,7 +40,7 @@ export function TableFilterDateRange({
 }) {
   useTableFilterRegistration(recordFieldPath, defaultValue, { exactMatch: false, isDateRange: true, dateRangeDateFormat: dateFormat });
   const { state: { tableId } } = useTableContext();
-  const poppupContentRef = useRef(/** @type {HTMLDivElement | null} */(null));
+  const popupContentRef = useRef(/** @type {HTMLDivElement | null} */(null));
   const [state, setState] = useImmer({ isPopupOpen: false });
 
   const {
@@ -74,7 +74,7 @@ export function TableFilterDateRange({
 
   return (
     <th className={joinClassNames('table-header__cell table-header__cell--filter-date', className)} id={id ?? undefined} ref={innerRef}>
-      <div ref={poppupContentRef}>
+      <div ref={popupContentRef}>
         <Button
           aria-controls={popupId}
           aria-expanded={state.isPopupOpen}
@@ -141,7 +141,7 @@ export function TableFilterDateRange({
         isPopupOpen={state.isPopupOpen}
         onChange={currentOnChange}
         setIsPopupOpen={(newIsPopupOpen) => setState((draftState) => { draftState.isPopupOpen = newIsPopupOpen; })}
-        poppupReferenceElement={poppupContentRef}
+        popupReferenceElement={popupContentRef}
         tableFilterDateId={id}
         value={currentValue || ''}
       />

--- a/@utahdts/utah-design-system/react/components/table/TableFilterDateRange.jsx
+++ b/@utahdts/utah-design-system/react/components/table/TableFilterDateRange.jsx
@@ -40,7 +40,7 @@ export function TableFilterDateRange({
 }) {
   useTableFilterRegistration(recordFieldPath, defaultValue, { exactMatch: false, isDateRange: true, dateRangeDateFormat: dateFormat });
   const { state: { tableId } } = useTableContext();
-  const popperContentRef = useRef(/** @type {HTMLDivElement | null} */(null));
+  const poppupContentRef = useRef(/** @type {HTMLDivElement | null} */(null));
   const [state, setState] = useImmer({ isPopupOpen: false });
 
   const {
@@ -74,7 +74,7 @@ export function TableFilterDateRange({
 
   return (
     <th className={joinClassNames('table-header__cell table-header__cell--filter-date', className)} id={id ?? undefined} ref={innerRef}>
-      <div ref={popperContentRef}>
+      <div ref={poppupContentRef}>
         <Button
           aria-controls={popupId}
           aria-expanded={state.isPopupOpen}
@@ -141,7 +141,7 @@ export function TableFilterDateRange({
         isPopupOpen={state.isPopupOpen}
         onChange={currentOnChange}
         setIsPopupOpen={(newIsPopupOpen) => setState((draftState) => { draftState.isPopupOpen = newIsPopupOpen; })}
-        popperReferenceElement={popperContentRef}
+        poppupReferenceElement={poppupContentRef}
         tableFilterDateId={id}
         value={currentValue || ''}
       />

--- a/@utahdts/utah-design-system/react/components/table/TableFilterDateRangePopup.jsx
+++ b/@utahdts/utah-design-system/react/components/table/TableFilterDateRangePopup.jsx
@@ -95,7 +95,6 @@ export function TableFilterDateRangePopup({
       id={id}
       isVisible={isPopupOpen}
       onVisibleChange={(_, isVisible) => setIsPopupOpen(isVisible)}
-      popperUpdateDependencies={[beginDateStr, endDateStr]}
       referenceElement={popperReferenceElement}
       role="dialog"
     >

--- a/@utahdts/utah-design-system/react/components/table/TableFilterDateRangePopup.jsx
+++ b/@utahdts/utah-design-system/react/components/table/TableFilterDateRangePopup.jsx
@@ -33,7 +33,7 @@ function formatNewValue(whichInput, newValue, currentBeginDate, currentEndDate) 
  * @param {string} props.id
  * @param {boolean} props.isPopupOpen
  * @param {(newValue: string) => void} props.onChange
- * @param {import('react').RefObject<HTMLDivElement | null>} props.popperReferenceElement
+ * @param {import('react').RefObject<HTMLDivElement | null>} props.poppupReferenceElement
  * @param {(isPopupOpen: boolean) => void} props.setIsPopupOpen
  * @param {string} props.tableFilterDateId
  * @param {string} props.value
@@ -44,7 +44,7 @@ export function TableFilterDateRangePopup({
   id,
   isPopupOpen,
   onChange,
-  popperReferenceElement,
+  poppupReferenceElement,
   setIsPopupOpen,
   tableFilterDateId,
   value,
@@ -95,7 +95,7 @@ export function TableFilterDateRangePopup({
       id={id}
       isVisible={isPopupOpen}
       onVisibleChange={(_, isVisible) => setIsPopupOpen(isVisible)}
-      referenceElement={popperReferenceElement}
+      referenceElement={poppupReferenceElement}
       role="dialog"
     >
       <div className="flex gap-xs full-width">

--- a/@utahdts/utah-design-system/react/components/table/TableFilterDateRangePopup.jsx
+++ b/@utahdts/utah-design-system/react/components/table/TableFilterDateRangePopup.jsx
@@ -33,7 +33,7 @@ function formatNewValue(whichInput, newValue, currentBeginDate, currentEndDate) 
  * @param {string} props.id
  * @param {boolean} props.isPopupOpen
  * @param {(newValue: string) => void} props.onChange
- * @param {import('react').RefObject<HTMLDivElement | null>} props.poppupReferenceElement
+ * @param {import('react').RefObject<HTMLDivElement | null>} props.popupReferenceElement
  * @param {(isPopupOpen: boolean) => void} props.setIsPopupOpen
  * @param {string} props.tableFilterDateId
  * @param {string} props.value
@@ -44,7 +44,7 @@ export function TableFilterDateRangePopup({
   id,
   isPopupOpen,
   onChange,
-  poppupReferenceElement,
+  popupReferenceElement,
   setIsPopupOpen,
   tableFilterDateId,
   value,
@@ -95,7 +95,7 @@ export function TableFilterDateRangePopup({
       id={id}
       isVisible={isPopupOpen}
       onVisibleChange={(_, isVisible) => setIsPopupOpen(isVisible)}
-      referenceElement={poppupReferenceElement}
+      referenceElement={popupReferenceElement}
       role="dialog"
     >
       <div className="flex gap-xs full-width">

--- a/@utahdts/utah-design-system/react/components/tooltip/Tooltip.jsx
+++ b/@utahdts/utah-design-system/react/components/tooltip/Tooltip.jsx
@@ -15,7 +15,7 @@ import { joinClassNames } from '../../util/joinClassNames';
  * @param {string} [props.className] CSS class to apply to the popup
  * @param {import('react').MutableRefObject<HTMLDivElement | null>} [props.innerRef] ref of the popup wrapper
  * @param {boolean} [props.isPopperVisible] controlled value for telling if tool tip is visible
- * @param {number | {mainAxis: number, crossAxis: number, alignmentAxis: number}} [props.offsetProp] default offset is [0, 5] (see popper documentation for details)
+ * @param {number | {mainAxis: number, crossAxis: number, alignmentAxis: number}} [props.position] default offset is [0, 5] (see popper documentation for details)
  * @param {PopupPlacement} [props.placement] where to put the tooltip in reference to the referenceElement
  * @param {HTMLElement | null} props.referenceElement the referenceElement from which the tool tip will toggle (first render will most likely be null)
  * @returns {import('react').JSX.Element}
@@ -25,7 +25,7 @@ export function Tooltip({
   className,
   innerRef: draftInnerRef,
   isPopperVisible,
-  offsetProp = 5,
+  position = 5,
   placement = popupPlacement.BOTTOM,
   referenceElement: draftReferenceElement,
 }) {
@@ -38,7 +38,7 @@ export function Tooltip({
       floating: popperElement,
     },
     middleware: [
-      offset(offsetProp),
+      offset(position),
       flip(),
       shift(),
       arrow({

--- a/@utahdts/utah-design-system/react/components/tooltip/Tooltip.jsx
+++ b/@utahdts/utah-design-system/react/components/tooltip/Tooltip.jsx
@@ -9,13 +9,13 @@ import { joinClassNames } from '../../util/joinClassNames';
 /**
  * A ToolTip is only in charge of positioning and rendering a tooltip.
  * Pass in a "referenceElement" to have "zero-config" for onMouseEnter and onMouseLeave triggering
- * Pass in a isPoppupVisible and setIsPoppupVisible to have it be a controlled component
+ * Pass in a isPopupVisible and setIsPopupVisible to have it be a controlled component
  * @param {object} props
  * @param {import('react').ReactNode} props.children The content of the tool tip
  * @param {string} [props.className] CSS class to apply to the popup
  * @param {import('react').MutableRefObject<HTMLDivElement | null>} [props.innerRef] ref of the popup wrapper
- * @param {boolean} [props.isPoppupVisible] controlled value for telling if tool tip is visible
- * @param {number | {mainAxis: number, crossAxis: number, alignmentAxis: number}} [props.position] default offset is [0, 5] (see poppup documentation for details)
+ * @param {boolean} [props.isPopupVisible] controlled value for telling if tool tip is visible
+ * @param {number | {mainAxis: number, crossAxis: number, alignmentAxis: number}} [props.position] default offset is [0, 5] (see popup documentation for details)
  * @param {PopupPlacement} [props.placement] where to put the tooltip in reference to the referenceElement
  * @param {HTMLElement | null} props.referenceElement the referenceElement from which the tool tip will toggle (first render will most likely be null)
  * @returns {import('react').JSX.Element}
@@ -24,18 +24,18 @@ export function Tooltip({
   children,
   className,
   innerRef: draftInnerRef,
-  isPoppupVisible,
+  isPopupVisible,
   position = 5,
   placement = popupPlacement.BOTTOM,
   referenceElement: draftReferenceElement,
 }) {
-  const [isPoppupVisibleInternal, setIsPoppupVisibleInternal] = useState(false);
-  const [poppupElement, setPoppupElement] = /** @type {typeof useState<HTMLDivElement | null>} */ (useState)(null);
+  const [isPopupVisibleInternal, setIsPopupVisibleInternal] = useState(false);
+  const [popupElement, setPopupElement] = /** @type {typeof useState<HTMLDivElement | null>} */ (useState)(null);
   const [arrowElement, setArrowElement] = /** @type {typeof useState<HTMLDivElement | null>} */ (useState)(null);
   const { floatingStyles, middlewareData } = useFloating({
     elements: {
       reference: draftReferenceElement,
-      floating: poppupElement,
+      floating: popupElement,
     },
     middleware: [
       offset(position),
@@ -45,7 +45,7 @@ export function Tooltip({
         element: arrowElement,
       }),
     ],
-    open: !(isPoppupVisible ?? isPoppupVisibleInternal),
+    open: !(isPopupVisible ?? isPopupVisibleInternal),
     placement,
     whileElementsMounted: autoUpdate,
   });
@@ -55,7 +55,7 @@ export function Tooltip({
   useEffect(
     () => {
       // parent is not controlling visibility, so hookup visibility to the `referenceElement`
-      if (draftReferenceElement && isPoppupVisible === undefined) {
+      if (draftReferenceElement && isPopupVisible === undefined) {
         if (draftReferenceElement.onmouseenter) {
           throw new Error('ToolTip: onMouseEnter previously set');
         }
@@ -70,18 +70,18 @@ export function Tooltip({
         }
         draftReferenceElement.onmouseenter = () => (
           startPopupTimer(() => {
-            setIsPoppupVisibleInternal(true);
+            setIsPopupVisibleInternal(true);
           })
         );
         // onfocus and onblur don't wait on the popupTimer to popup
         draftReferenceElement.onfocus = () => {
-          setIsPoppupVisibleInternal(true);
+          setIsPopupVisibleInternal(true);
         };
         draftReferenceElement.onmouseleave = () => {
           startNoPopupTimer();
-          setIsPoppupVisibleInternal(false);
+          setIsPopupVisibleInternal(false);
         };
-        draftReferenceElement.onblur = () => setIsPoppupVisibleInternal(false);
+        draftReferenceElement.onblur = () => setIsPopupVisibleInternal(false);
       }
       return (
         () => {
@@ -94,13 +94,13 @@ export function Tooltip({
         }
       );
     },
-    [draftReferenceElement, isPoppupVisible, startNoPopupTimer, startPopupTimer]
+    [draftReferenceElement, isPopupVisible, startNoPopupTimer, startPopupTimer]
   );
 
   return (
     <div
       ref={(refValue) => {
-        setPoppupElement(refValue);
+        setPopupElement(refValue);
         if (draftInnerRef) {
           draftInnerRef.current = refValue;
         }
@@ -109,10 +109,10 @@ export function Tooltip({
       className={joinClassNames(
         className,
         'tooltip__wrapper',
-        (!(isPoppupVisible ?? isPoppupVisibleInternal)) && 'tooltip__wrapper--hidden'
+        (!(isPopupVisible ?? isPopupVisibleInternal)) && 'tooltip__wrapper--hidden'
       )}
       aria-hidden="true"
-      data-poppup-placement={placement}
+      data-popup-placement={placement}
     >
       <div className="tooltip__content">
         {children}

--- a/@utahdts/utah-design-system/react/components/tooltip/Tooltip.jsx
+++ b/@utahdts/utah-design-system/react/components/tooltip/Tooltip.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useFloating, autoUpdate, offset, shift, flip, arrow } from '@floating-ui/react-dom';
+import { useFloating, autoUpdate, offset as floatingOffset, shift, flip, arrow } from '@floating-ui/react-dom';
 import { popupPlacement } from '../../enums/popupPlacement';
 import { usePopupDelay } from '../../hooks/usePopupDelay';
 import { joinClassNames } from '../../util/joinClassNames';
@@ -15,7 +15,8 @@ import { joinClassNames } from '../../util/joinClassNames';
  * @param {string} [props.className] CSS class to apply to the popup
  * @param {import('react').MutableRefObject<HTMLDivElement | null>} [props.innerRef] ref of the popup wrapper
  * @param {boolean} [props.isPopupVisible] controlled value for telling if tool tip is visible
- * @param {number | {mainAxis: number, crossAxis: number, alignmentAxis: number}} [props.position] default offset is [0, 5] (see popup documentation for details)
+ * @param {number | {mainAxis: number, crossAxis: number, alignmentAxis?: number}} [props.offset] default offset is 5 (see popup documentation
+ * for details)
  * @param {PopupPlacement} [props.placement] where to put the tooltip in reference to the referenceElement
  * @param {HTMLElement | null} props.referenceElement the referenceElement from which the tool tip will toggle (first render will most likely be null)
  * @returns {import('react').JSX.Element}
@@ -25,7 +26,7 @@ export function Tooltip({
   className,
   innerRef: draftInnerRef,
   isPopupVisible,
-  position = 5,
+  offset = 5,
   placement = popupPlacement.BOTTOM,
   referenceElement: draftReferenceElement,
 }) {
@@ -38,7 +39,7 @@ export function Tooltip({
       floating: popupElement,
     },
     middleware: [
-      offset(position),
+      floatingOffset(offset),
       flip(),
       shift(),
       arrow({

--- a/@utahdts/utah-design-system/react/components/tooltip/Tooltip.jsx
+++ b/@utahdts/utah-design-system/react/components/tooltip/Tooltip.jsx
@@ -9,13 +9,13 @@ import { joinClassNames } from '../../util/joinClassNames';
 /**
  * A ToolTip is only in charge of positioning and rendering a tooltip.
  * Pass in a "referenceElement" to have "zero-config" for onMouseEnter and onMouseLeave triggering
- * Pass in a isPopperVisible and setIsPopperVisible to have it be a controlled component
+ * Pass in a isPoppupVisible and setIsPoppupVisible to have it be a controlled component
  * @param {object} props
  * @param {import('react').ReactNode} props.children The content of the tool tip
  * @param {string} [props.className] CSS class to apply to the popup
  * @param {import('react').MutableRefObject<HTMLDivElement | null>} [props.innerRef] ref of the popup wrapper
- * @param {boolean} [props.isPopperVisible] controlled value for telling if tool tip is visible
- * @param {number | {mainAxis: number, crossAxis: number, alignmentAxis: number}} [props.position] default offset is [0, 5] (see popper documentation for details)
+ * @param {boolean} [props.isPoppupVisible] controlled value for telling if tool tip is visible
+ * @param {number | {mainAxis: number, crossAxis: number, alignmentAxis: number}} [props.position] default offset is [0, 5] (see poppup documentation for details)
  * @param {PopupPlacement} [props.placement] where to put the tooltip in reference to the referenceElement
  * @param {HTMLElement | null} props.referenceElement the referenceElement from which the tool tip will toggle (first render will most likely be null)
  * @returns {import('react').JSX.Element}
@@ -24,18 +24,18 @@ export function Tooltip({
   children,
   className,
   innerRef: draftInnerRef,
-  isPopperVisible,
+  isPoppupVisible,
   position = 5,
   placement = popupPlacement.BOTTOM,
   referenceElement: draftReferenceElement,
 }) {
-  const [isPopperVisibleInternal, setIsPopperVisibleInternal] = useState(false);
-  const [popperElement, setPopperElement] = /** @type {typeof useState<HTMLDivElement | null>} */ (useState)(null);
+  const [isPoppupVisibleInternal, setIsPoppupVisibleInternal] = useState(false);
+  const [poppupElement, setPoppupElement] = /** @type {typeof useState<HTMLDivElement | null>} */ (useState)(null);
   const [arrowElement, setArrowElement] = /** @type {typeof useState<HTMLDivElement | null>} */ (useState)(null);
   const { floatingStyles, middlewareData } = useFloating({
     elements: {
       reference: draftReferenceElement,
-      floating: popperElement,
+      floating: poppupElement,
     },
     middleware: [
       offset(position),
@@ -45,7 +45,7 @@ export function Tooltip({
         element: arrowElement,
       }),
     ],
-    open: !(isPopperVisible ?? isPopperVisibleInternal),
+    open: !(isPoppupVisible ?? isPoppupVisibleInternal),
     placement,
     whileElementsMounted: autoUpdate,
   });
@@ -55,7 +55,7 @@ export function Tooltip({
   useEffect(
     () => {
       // parent is not controlling visibility, so hookup visibility to the `referenceElement`
-      if (draftReferenceElement && isPopperVisible === undefined) {
+      if (draftReferenceElement && isPoppupVisible === undefined) {
         if (draftReferenceElement.onmouseenter) {
           throw new Error('ToolTip: onMouseEnter previously set');
         }
@@ -70,18 +70,18 @@ export function Tooltip({
         }
         draftReferenceElement.onmouseenter = () => (
           startPopupTimer(() => {
-            setIsPopperVisibleInternal(true);
+            setIsPoppupVisibleInternal(true);
           })
         );
         // onfocus and onblur don't wait on the popupTimer to popup
         draftReferenceElement.onfocus = () => {
-          setIsPopperVisibleInternal(true);
+          setIsPoppupVisibleInternal(true);
         };
         draftReferenceElement.onmouseleave = () => {
           startNoPopupTimer();
-          setIsPopperVisibleInternal(false);
+          setIsPoppupVisibleInternal(false);
         };
-        draftReferenceElement.onblur = () => setIsPopperVisibleInternal(false);
+        draftReferenceElement.onblur = () => setIsPoppupVisibleInternal(false);
       }
       return (
         () => {
@@ -94,13 +94,13 @@ export function Tooltip({
         }
       );
     },
-    [draftReferenceElement, isPopperVisible, startNoPopupTimer, startPopupTimer]
+    [draftReferenceElement, isPoppupVisible, startNoPopupTimer, startPopupTimer]
   );
 
   return (
     <div
       ref={(refValue) => {
-        setPopperElement(refValue);
+        setPoppupElement(refValue);
         if (draftInnerRef) {
           draftInnerRef.current = refValue;
         }
@@ -109,10 +109,10 @@ export function Tooltip({
       className={joinClassNames(
         className,
         'tooltip__wrapper',
-        (!(isPopperVisible ?? isPopperVisibleInternal)) && 'tooltip__wrapper--hidden'
+        (!(isPoppupVisible ?? isPoppupVisibleInternal)) && 'tooltip__wrapper--hidden'
       )}
       aria-hidden="true"
-      data-popper-placement={placement}
+      data-poppup-placement={placement}
     >
       <div className="tooltip__content">
         {children}

--- a/@utahdts/utah-design-system/react/components/tooltip/Tooltip.jsx
+++ b/@utahdts/utah-design-system/react/components/tooltip/Tooltip.jsx
@@ -49,7 +49,6 @@ export function Tooltip({
     placement,
     whileElementsMounted: autoUpdate,
   });
-  // const updateRef = useRefAlways(update);
 
   const { startNoPopupTimer, startPopupTimer } = usePopupDelay();
 

--- a/@utahdts/utah-design-system/react/enums/popupPlacement.js
+++ b/@utahdts/utah-design-system/react/enums/popupPlacement.js
@@ -6,9 +6,6 @@
 
 /** @enum {PopupPlacement} */
 export const popupPlacement = {
-  AUTO: /** @type {PopupPlacement} */ ('auto'),
-  AUTO_START: /** @type {PopupPlacement} */ ('auto-start'),
-  AUTO_END: /** @type {PopupPlacement} */ ('auto-end'),
   BOTTOM: /** @type {PopupPlacement} */ ('bottom'),
   BOTTOM_START: /** @type {PopupPlacement} */ ('bottom-start'),
   BOTTOM_END: /** @type {PopupPlacement} */ ('bottom-end'),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **[Breaking]** Changed library used to position tooltips / popups. 
 Some props have been updated accordingly.
   - `ComboBox`:
-    - `popperContentRef` is now `poppupContentRef`
+    - `popperContentRef` is now `popupContentRef`
   - `Popup`:
     - `offset` is now `position`:
       - from `[number, number]` to `number | {mainAxis: number, crossAxis: number, alignmentAxis: number}`
@@ -19,15 +19,15 @@ Some props have been updated accordingly.
     - `popperUpdateDependencies` has been removed
     - `placement` default value is now `popupPlacement.BOTTOM`
       - values `'auto'`, `'auto-start'` and `'auto-end'` have been removed
-    - CSS change: `data-popper-placement` is now `data-poppup-placement`
+    - CSS change: `data-popper-placement` is now `data-popup-placement`
   - `TableFilterDateRangePopup`:
-    - `popperReferenceElement` is now `poppupReferenceElement`
+    - `popperReferenceElement` is now `popupReferenceElement`
   - `Tooltip`:
-    - `isPopperVisible` is now `isPoppupVisible`
+    - `isPopperVisible` is now `isPopupVisible`
     - `offset` is now `position`
       - from `[number, number]` to `number | {mainAxis: number, crossAxis: number, alignmentAxis: number}`
       - default value is now `5`
-    - CSS change: `data-popper-placement` is now `data-poppup-placement`
+    - CSS change: `data-popper-placement` is now `data-popup-placement`
 
 # [3.0.5] 03/18/2025
 ## Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [4.0.0] 05/12/2025
+## Breaking Changes
+- **[Breaking]** Update React to version `19.1.0`
+- **[Breaking]** Changed library used to position tooltips / popups. 
+Some props have been updated accordingly.
+  - `ComboBox`:
+    - `popperContentRef` is now `poppupContentRef`
+  - `Popup`:
+    - `offset` is now `position`:
+      - from `[number, number]` to `number | {mainAxis: number, crossAxis: number, alignmentAxis: number}`
+      - default value is now `{mainAxis: 10, crossAxis: 0, alignmentAxis: 0}`
+    - `popperUpdateDependencies` has been removed
+    - `placement` default value is now `popupPlacement.BOTTOM`
+      - values `'auto'`, `'auto-start'` and `'auto-end'` have been removed
+    - CSS change: `data-popper-placement` is now `data-poppup-placement`
+  - `TableFilterDateRangePopup`:
+    - `popperReferenceElement` is now `poppupReferenceElement`
+  - `Tooltip`:
+    - `isPopperVisible` is now `isPoppupVisible`
+    - `offset` is now `position`
+      - from `[number, number]` to `number | {mainAxis: number, crossAxis: number, alignmentAxis: number}`
+      - default value is now `5`
+    - CSS change: `data-popper-placement` is now `data-poppup-placement`
+
 # [3.0.5] 03/18/2025
 ## Fixed
 - Fixed mobile UtahId button to only sign in if not signed in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # [4.0.0] 05/12/2025
 ## Breaking Changes
 - **[Breaking]** Update React to version `19.1.0`
+  - You must upgrade to `React 19` to use `v4.0.0`
 - **[Breaking]** Changed library used to position tooltips / popups. 
 Some props have been updated accordingly.
   - `ComboBox`:
     - `popperContentRef` is now `popupContentRef`
   - `Popup`:
-    - `offset` is now `position`:
+    - `offset` type is now:
       - from `[number, number]` to `number | {mainAxis: number, crossAxis: number, alignmentAxis: number}`
       - default value is now `{mainAxis: 10, crossAxis: 0, alignmentAxis: 0}`
     - `popperUpdateDependencies` has been removed
@@ -24,7 +25,7 @@ Some props have been updated accordingly.
     - `popperReferenceElement` is now `popupReferenceElement`
   - `Tooltip`:
     - `isPopperVisible` is now `isPopupVisible`
-    - `offset` is now `position`
+    - `offset` type is now
       - from `[number, number]` to `number | {mainAxis: number, crossAxis: number, alignmentAxis: number}`
       - default value is now `5`
     - CSS change: `data-popper-placement` is now `data-popup-placement`

--- a/utah-design-system-website/package.json
+++ b/utah-design-system-website/package.json
@@ -23,6 +23,7 @@
     "@utahdts/utah-design-system": "3.0.5",
     "@utahdts/utah-design-system-header": "3.0.5",
     "date-fns": "4.1.0",
+    "js-beautify": "1.15.4",
     "lodash": "4.17.21",
     "prop-types": "15.8.1",
     "react": "^19.1.0",

--- a/utah-design-system-website/package.json
+++ b/utah-design-system-website/package.json
@@ -24,7 +24,6 @@
     "@utahdts/utah-design-system": "3.0.5",
     "@utahdts/utah-design-system-header": "3.0.5",
     "date-fns": "4.1.0",
-    "js-beautify": "1.15.4",
     "lodash": "4.17.21",
     "prop-types": "15.8.1",
     "react": "^19.1.0",
@@ -36,6 +35,7 @@
     "use-immer": "0.11.0"
   },
   "devDependencies": {
+    "@types/js-beautify": "^1.14.3",
     "@types/react": "19.0.12",
     "@types/react-dom": "19.0.4",
     "@types/tinycolor2": "1.4.6",

--- a/utah-design-system-website/package.json
+++ b/utah-design-system-website/package.json
@@ -26,15 +26,15 @@
     "js-beautify": "1.15.4",
     "lodash": "4.17.21",
     "prop-types": "15.8.1",
-    "react": "^19.1.0",
+    "react": "19.1.0",
     "react-colorful": "5.6.1",
-    "react-dom": "^19.1.0",
+    "react-dom": "19.1.0",
     "react-router-dom": "7.4.0",
     "tinycolor2": "1.6.0",
     "use-immer": "0.11.0"
   },
   "devDependencies": {
-    "@types/js-beautify": "^1.14.3",
+    "@types/js-beautify": "1.14.3",
     "@types/react": "19.0.12",
     "@types/react-dom": "19.0.4",
     "@types/tinycolor2": "1.4.6",

--- a/utah-design-system-website/package.json
+++ b/utah-design-system-website/package.json
@@ -20,7 +20,6 @@
     "testOnce": "vitest run"
   },
   "dependencies": {
-    "@popperjs/core": "2.11.8",
     "@utahdts/utah-design-system": "3.0.5",
     "@utahdts/utah-design-system-header": "3.0.5",
     "date-fns": "4.1.0",
@@ -29,7 +28,6 @@
     "react": "^19.1.0",
     "react-colorful": "5.6.1",
     "react-dom": "^19.1.0",
-    "react-popper": "2.3.0",
     "react-router-dom": "7.4.0",
     "tinycolor2": "1.6.0",
     "use-immer": "0.11.0"

--- a/utah-design-system-website/package.json
+++ b/utah-design-system-website/package.json
@@ -20,17 +20,15 @@
     "testOnce": "vitest run"
   },
   "dependencies": {
-    "@popperjs/core": "2.11.8",
     "@utahdts/utah-design-system": "3.0.5",
     "@utahdts/utah-design-system-header": "3.0.5",
     "date-fns": "4.1.0",
     "js-beautify": "1.15.4",
     "lodash": "4.17.21",
     "prop-types": "15.8.1",
-    "react": "18.3.1",
+    "react": "^19.1.0",
     "react-colorful": "5.6.1",
-    "react-dom": "18.3.1",
-    "react-popper": "2.3.0",
+    "react-dom": "^19.1.0",
     "react-router-dom": "7.4.0",
     "tinycolor2": "1.6.0",
     "use-immer": "0.11.0"

--- a/utah-design-system-website/package.json
+++ b/utah-design-system-website/package.json
@@ -20,6 +20,7 @@
     "testOnce": "vitest run"
   },
   "dependencies": {
+    "@popperjs/core": "2.11.8",
     "@utahdts/utah-design-system": "3.0.5",
     "@utahdts/utah-design-system-header": "3.0.5",
     "date-fns": "4.1.0",
@@ -29,6 +30,7 @@
     "react": "^19.1.0",
     "react-colorful": "5.6.1",
     "react-dom": "^19.1.0",
+    "react-popper": "2.3.0",
     "react-router-dom": "7.4.0",
     "tinycolor2": "1.6.0",
     "use-immer": "0.11.0"

--- a/utah-design-system-website/src/@types/jsDocTypes.d.js
+++ b/utah-design-system-website/src/@types/jsDocTypes.d.js
@@ -443,7 +443,7 @@
 
 /**
  * @typedef TooltipsExamplePropsShape {
- *  @property {boolean} isPoppupVisible
+ *  @property {boolean} isPopupVisible
  *  @property {string} offsetDistance
  *  @property {string} offsetSkidding
  *  @property {PopupPlacement} placement

--- a/utah-design-system-website/src/@types/jsDocTypes.d.js
+++ b/utah-design-system-website/src/@types/jsDocTypes.d.js
@@ -443,7 +443,7 @@
 
 /**
  * @typedef TooltipsExamplePropsShape {
- *  @property {boolean} isPopperVisible
+ *  @property {boolean} isPoppupVisible
  *  @property {string} offsetDistance
  *  @property {string} offsetSkidding
  *  @property {PopupPlacement} placement

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/popups/popups/PopupsDocumentation.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/popups/popups/PopupsDocumentation.jsx
@@ -608,15 +608,16 @@ export function PopupsDocumentation() {
                       </TableCell>
                     </TableRow>
                     <TableRow>
-                      <TableCell><code className="primary-color">offset</code></TableCell>
+                      <TableCell><code className="primary-color">position</code></TableCell>
                       <TableCell>
-                        <div className="props-code-wrapper">
-                          <code>array of numbers</code>
-                        </div>
+                        <code>number</code>
+                        <span> | </span>
+                        <code>&#123;mainAxis: number, crossAxis: number, alignmentAxis: number&#125;</code>
                       </TableCell>
-                      <TableCell>[0, 10]</TableCell>
+                      <TableCell><code>&#123;mainAxis: 10, crossAxis: 0, alignmentAxis: 0&#125;</code></TableCell>
                       <TableCell>
-                        The offset used by Popper to position the popup.
+                        Control the popup distance from its anchor.<br />
+                        See <ExternalLink href="https://floating-ui.com/docs/offset">official documentation</ExternalLink>.
                       </TableCell>
                     </TableRow>
                     <TableRow>
@@ -641,18 +642,6 @@ export function PopupsDocumentation() {
                       <TableCell>popupPlacement.BOTTOM</TableCell>
                       <TableCell>
                         The default placement of the popup. See the popupPlacement ENUM for the correct values to use.
-                      </TableCell>
-                    </TableRow>
-                    <TableRow>
-                      <TableCell><code className="primary-color">popperUpdateDependencies</code></TableCell>
-                      <TableCell>
-                        <div className="props-code-wrapper">
-                          <code>any[]</code>
-                        </div>
-                      </TableCell>
-                      <TableCell>null</TableCell>
-                      <TableCell>
-                        <code>useEffect</code> dependencies for updating popper placement.
                       </TableCell>
                     </TableRow>
                     <TableRow>

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/popups/popups/PopupsDocumentation.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/popups/popups/PopupsDocumentation.jsx
@@ -608,7 +608,7 @@ export function PopupsDocumentation() {
                       </TableCell>
                     </TableRow>
                     <TableRow>
-                      <TableCell><code className="primary-color">position</code></TableCell>
+                      <TableCell><code className="primary-color">offset</code></TableCell>
                       <TableCell>
                         <code>number</code>
                         <span> | </span>

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/popups/popups/PopupsDocumentation.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/popups/popups/PopupsDocumentation.jsx
@@ -638,7 +638,7 @@ export function PopupsDocumentation() {
                           <code>string</code>
                         </div>
                       </TableCell>
-                      <TableCell>popupPlacement.AUTO</TableCell>
+                      <TableCell>popupPlacement.BOTTOM</TableCell>
                       <TableCell>
                         The default placement of the popup. See the popupPlacement ENUM for the correct values to use.
                       </TableCell>

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/tooltips/TooltipsDocumentation.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/tooltips/TooltipsDocumentation.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable max-len */
 import {
+  ExternalLink,
   ICON_BUTTON_APPEARANCE, IconButton, popupPlacement, Tab, TabGroup, TabList, TabPanel, TabPanels, useBanner
 } from '@utahdts/utah-design-system';
 import { Link } from 'react-router-dom';
@@ -35,6 +36,28 @@ export function TooltipsDocumentation() {
         PROPS_EXAMPLE={TooltipsExampleProps}
         CODE_EXAMPLE={TooltipsExampleCodeReact}
       />
+      <div className="home-page__color-card home-page__card-wide mb-spacing-l">
+        <h3 className="home-page__color-card-title flex mb-spacing-xs"><span className="utds-icon-before-info mr-spacing-xs" aria-hidden="true" /> Note
+        </h3>
+        <p>
+          Starting with version <code className="color-picker--light">4.0.0</code>, the Design System uses <code className="color-picker--light">@floating-ui/react-dom</code>.
+        </p>
+        <p>
+          The offset property has been updated accordingly. You will need to make the following changes:
+        </p>
+        <PreCodeForCodeString
+          className="gray-block color-picker--light my-spacing"
+          codeRaw={`// Before
+offset: [0, 10]
+
+// Now
+offset: {
+  mainAxis: 10,
+  crossAxis: 0
+}`}
+        />
+        See <ExternalLink href="https://floating-ui.com/docs/offset">official documentation</ExternalLink>.
+      </div>
       <StaticExample
         title="Tooltip Example"
         renderedExample={(

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/tooltips/TooltipsDocumentation.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/tooltips/TooltipsDocumentation.jsx
@@ -25,7 +25,7 @@ export function TooltipsDocumentation() {
       <h2 id="section-example">Example</h2>
       <SandboxExample
         defaultProps={{
-          isPopperVisible: false,
+          isPoppupVisible: false,
           offsetDistance: '0',
           offsetSkidding: '5',
           placement: popupPlacement.BOTTOM,

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/tooltips/TooltipsDocumentation.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/tooltips/TooltipsDocumentation.jsx
@@ -25,7 +25,7 @@ export function TooltipsDocumentation() {
       <h2 id="section-example">Example</h2>
       <SandboxExample
         defaultProps={{
-          isPoppupVisible: false,
+          isPopupVisible: false,
           offsetDistance: '0',
           offsetSkidding: '5',
           placement: popupPlacement.BOTTOM,

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/tooltips/TooltipsExampleCodeReact.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/tooltips/TooltipsExampleCodeReact.jsx
@@ -13,7 +13,7 @@ import { SandboxIndent } from '../../../../sandbox/SandboxIndent';
 export function TooltipsExampleCodeReact({
   state: {
     props: {
-      isPopperVisible,
+      isPoppupVisible,
       offsetDistance,
       offsetSkidding,
       placement,
@@ -56,7 +56,7 @@ export function TooltipsExampleCodeReact({
 
       &lt;Tooltip
       <br />
-      <ExampleCodeReactProp displayProp={isPopperVisible ? 'isPopperVisible' : null} indentLevel={1} />
+      <ExampleCodeReactProp displayProp={isPoppupVisible ? 'isPoppupVisible' : null} indentLevel={1} />
       {
         position
           ? <ExampleCodeReactProp displayProp={position} indentLevel={1} />

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/tooltips/TooltipsExampleCodeReact.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/tooltips/TooltipsExampleCodeReact.jsx
@@ -25,7 +25,7 @@ export function TooltipsExampleCodeReact({
   const offsetSkiddingUse = Number(offsetSkidding) || 0;
   const position = (
     (offsetDistanceUse !== 0 || offsetSkiddingUse !== 5)
-      ? `offset={[${offsetDistanceUse}, ${offsetSkiddingUse}]}`
+      ? `offset={{crossAxis: ${offsetDistanceUse}, mainAxis: ${offsetSkiddingUse}}}`
       : null
   );
 

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/tooltips/TooltipsExampleCodeReact.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/tooltips/TooltipsExampleCodeReact.jsx
@@ -13,7 +13,7 @@ import { SandboxIndent } from '../../../../sandbox/SandboxIndent';
 export function TooltipsExampleCodeReact({
   state: {
     props: {
-      isPoppupVisible,
+      isPopupVisible,
       offsetDistance,
       offsetSkidding,
       placement,
@@ -56,7 +56,7 @@ export function TooltipsExampleCodeReact({
 
       &lt;Tooltip
       <br />
-      <ExampleCodeReactProp displayProp={isPoppupVisible ? 'isPoppupVisible' : null} indentLevel={1} />
+      <ExampleCodeReactProp displayProp={isPopupVisible ? 'isPopupVisible' : null} indentLevel={1} />
       {
         position
           ? <ExampleCodeReactProp displayProp={position} indentLevel={1} />

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/tooltips/TooltipsExampleCodeReact.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/tooltips/TooltipsExampleCodeReact.jsx
@@ -23,7 +23,7 @@ export function TooltipsExampleCodeReact({
 }) {
   const offsetDistanceUse = Number(offsetDistance) || 0;
   const offsetSkiddingUse = Number(offsetSkidding) || 0;
-  const offsetProp = (
+  const position = (
     (offsetDistanceUse !== 0 || offsetSkiddingUse !== 5)
       ? `offset={[${offsetDistanceUse}, ${offsetSkiddingUse}]}`
       : null
@@ -58,8 +58,8 @@ export function TooltipsExampleCodeReact({
       <br />
       <ExampleCodeReactProp displayProp={isPopperVisible ? 'isPopperVisible' : null} indentLevel={1} />
       {
-        offsetProp
-          ? <ExampleCodeReactProp displayProp={offsetProp} indentLevel={1} />
+        position
+          ? <ExampleCodeReactProp displayProp={position} indentLevel={1} />
           : null
       }
       {

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/tooltips/TooltipsExampleProps.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/tooltips/TooltipsExampleProps.jsx
@@ -31,11 +31,11 @@ export function TooltipsExampleProps({ setState, state }) {
       />
 
       <Switch
-        id="props.isPopperVisible"
+        id="props.isPoppupVisible"
         label="Visible"
         // @ts-expect-error
         onChange={onChange}
-        value={valueFn('props.isPopperVisible')}
+        value={valueFn('props.isPoppupVisible')}
         width={20}
       />
 
@@ -68,7 +68,7 @@ export function TooltipsExampleProps({ setState, state }) {
         onChange={onChange}
         value={valueFn('props.offsetSkidding')}
       />
-      <ExternalLink href="https://popper.js.org/docs/v2/modifiers/offset/">Distance/Skidding Docs</ExternalLink>
+      <ExternalLink href="https://floating-ui.com/docs/offset">Distance/Skidding Docs</ExternalLink>
     </Form>
   );
 }

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/tooltips/TooltipsExampleProps.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/tooltips/TooltipsExampleProps.jsx
@@ -57,18 +57,18 @@ export function TooltipsExampleProps({ setState, state }) {
       <TextInput
         id="props.offsetDistance"
         className="input--height-small1x"
-        label="Distance"
+        label="crossAxis"
         onChange={onChange}
         value={valueFn('props.offsetDistance')}
       />
       <TextInput
         id="props.offsetSkidding"
         className="input--height-small1x"
-        label="Skidding"
+        label="mainAxis"
         onChange={onChange}
         value={valueFn('props.offsetSkidding')}
       />
-      <ExternalLink href="https://floating-ui.com/docs/offset">Distance/Skidding Docs</ExternalLink>
+      <ExternalLink href="https://floating-ui.com/docs/offset">crossAxis/mainAxis Docs</ExternalLink>
     </Form>
   );
 }

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/tooltips/TooltipsExampleProps.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/tooltips/TooltipsExampleProps.jsx
@@ -31,11 +31,11 @@ export function TooltipsExampleProps({ setState, state }) {
       />
 
       <Switch
-        id="props.isPoppupVisible"
+        id="props.isPopupVisible"
         label="Visible"
         // @ts-expect-error
         onChange={onChange}
-        value={valueFn('props.isPoppupVisible')}
+        value={valueFn('props.isPopupVisible')}
         width={20}
       />
 

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/tooltips/TooltipsExampleRender.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/tooltips/TooltipsExampleRender.jsx
@@ -13,7 +13,7 @@ import { useRef } from 'react';
 export function TooltipsExampleRender({
   state: {
     props: {
-      isPoppupVisible,
+      isPopupVisible,
       offsetDistance,
       offsetSkidding,
       placement,
@@ -35,7 +35,7 @@ export function TooltipsExampleRender({
         <span className="visually-hidden">{popupText}</span>
       </Button>
       <Tooltip
-        isPoppupVisible={isPoppupVisible || undefined}
+        isPopupVisible={isPopupVisible || undefined}
         position={{
           mainAxis: Number(offsetSkidding) || 0,
           crossAxis: Number(offsetDistance) || 0,

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/tooltips/TooltipsExampleRender.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/tooltips/TooltipsExampleRender.jsx
@@ -36,7 +36,7 @@ export function TooltipsExampleRender({
       </Button>
       <Tooltip
         isPopupVisible={isPopupVisible || undefined}
-        position={{
+        offset={{
           mainAxis: Number(offsetSkidding) || 0,
           crossAxis: Number(offsetDistance) || 0,
           alignmentAxis: 0

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/tooltips/TooltipsExampleRender.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/tooltips/TooltipsExampleRender.jsx
@@ -37,8 +37,8 @@ export function TooltipsExampleRender({
       <Tooltip
         isPopperVisible={isPopperVisible || undefined}
         position={{
-          mainAxis: Number(offsetDistance) || 0,
-          crossAxis: Number(offsetSkidding) || 0,
+          mainAxis: Number(offsetSkidding) || 0,
+          crossAxis: Number(offsetDistance) || 0,
           alignmentAxis: 0
         }}
         placement={placement}

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/tooltips/TooltipsExampleRender.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/tooltips/TooltipsExampleRender.jsx
@@ -13,7 +13,7 @@ import { useRef } from 'react';
 export function TooltipsExampleRender({
   state: {
     props: {
-      isPopperVisible,
+      isPoppupVisible,
       offsetDistance,
       offsetSkidding,
       placement,
@@ -35,7 +35,7 @@ export function TooltipsExampleRender({
         <span className="visually-hidden">{popupText}</span>
       </Button>
       <Tooltip
-        isPopperVisible={isPopperVisible || undefined}
+        isPoppupVisible={isPoppupVisible || undefined}
         position={{
           mainAxis: Number(offsetSkidding) || 0,
           crossAxis: Number(offsetDistance) || 0,

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/tooltips/TooltipsExampleRender.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/tooltips/TooltipsExampleRender.jsx
@@ -36,7 +36,11 @@ export function TooltipsExampleRender({
       </Button>
       <Tooltip
         isPopperVisible={isPopperVisible || undefined}
-        offset={[Number(offsetDistance) || 0, Number(offsetSkidding) || 0]}
+        position={{
+          mainAxis: Number(offsetDistance) || 0,
+          crossAxis: Number(offsetSkidding) || 0,
+          alignmentAxis: 0
+        }}
         placement={placement}
         referenceElement={referenceElement.current}
       >

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/tooltips/TootltipsPropsDocumentation.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/tooltips/TootltipsPropsDocumentation.jsx
@@ -32,7 +32,7 @@ export function TootltipsPropsDocumentation() {
       </TableRow>
 
       <TableRow>
-        <TableCell><code className="primary-color">isPoppupVisible</code></TableCell>
+        <TableCell><code className="primary-color">isPopupVisible</code></TableCell>
         <TableCell>
           <div className="props-code-wrapper">
             <code>true</code>

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/tooltips/TootltipsPropsDocumentation.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/tooltips/TootltipsPropsDocumentation.jsx
@@ -47,7 +47,7 @@ export function TootltipsPropsDocumentation() {
       </TableRow>
 
       <TableRow>
-        <TableCell><code className="primary-color">position</code></TableCell>
+        <TableCell><code className="primary-color">offset</code></TableCell>
         <TableCell>
           <code>number</code>
           <span> | </span>

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/tooltips/TootltipsPropsDocumentation.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/tooltips/TootltipsPropsDocumentation.jsx
@@ -32,7 +32,7 @@ export function TootltipsPropsDocumentation() {
       </TableRow>
 
       <TableRow>
-        <TableCell><code className="primary-color">isPopperVisible</code></TableCell>
+        <TableCell><code className="primary-color">isPoppupVisible</code></TableCell>
         <TableCell>
           <div className="props-code-wrapper">
             <code>true</code>
@@ -47,12 +47,16 @@ export function TootltipsPropsDocumentation() {
       </TableRow>
 
       <TableRow>
-        <TableCell><code className="primary-color">offset</code></TableCell>
-        <TableCell><code>[number, number]</code></TableCell>
-        <TableCell><code>[0, 5]</code></TableCell>
+        <TableCell><code className="primary-color">position</code></TableCell>
+        <TableCell>
+          <code>number</code>
+          <span> | </span>
+          <code>&#123;mainAxis: number, crossAxis: number, alignmentAxis: number&#125;</code>
+        </TableCell>
+        <TableCell><code>5</code></TableCell>
         <TableCell>
           Control the tooltip distance from its anchor.<br />
-          See <ExternalLink href="https://popper.js.org/docs/v2/tutorial/#offset">official documentation</ExternalLink>.
+          See <ExternalLink href="https://floating-ui.com/docs/offset">official documentation</ExternalLink>.
         </TableCell>
       </TableRow>
 
@@ -60,12 +64,6 @@ export function TootltipsPropsDocumentation() {
         <TableCell><code className="primary-color">placement</code></TableCell>
         <TableCell>
           <div className="props-code-wrapper">
-            <code>auto</code>
-            <span> | </span>
-            <code>auto-start</code>
-            <span> | </span>
-            <code>auto-end</code>
-            <span> | </span>
             <code>bottom</code>
             <span> | </span>
             <code>bottom-start</code>
@@ -94,7 +92,7 @@ export function TootltipsPropsDocumentation() {
         <TableCell><code>bottom</code></TableCell>
         <TableCell>
           How should the tooltip should be positioned from its anchor.<br />
-          See <ExternalLink href="https://popper.js.org/docs/v2/constructors/#options">official documentation</ExternalLink>.
+          See <ExternalLink href="https://floating-ui.com/docs/arrow#placement">official documentation</ExternalLink>.
         </TableCell>
       </TableRow>
 


### PR DESCRIPTION
- Upgrade React to version 19 for `@utahdts/utah-design-system` and website
- Migrate Popper to Floating UI:
  -  (`@utahdts/utah-design-system-header` is STILL using Popper),
  - Remove references to Popper throughout (documentation and props),
  - `"auto" | "auto-start" | "auto-end"` positions have been removed -> handled by middleware (`flip(), shift()`),
  - `popperUpdateDependencies` has been removed -> `whileElementsMounted: autoUpdate` handles it,
  - `offset` is now `position`.