### PR TITLE
Fix bundling issues

### DIFF
--- a/@utahdts/utah-design-system/package.json
+++ b/@utahdts/utah-design-system/package.json
@@ -70,7 +70,6 @@
     "date-fns": "4.1.0",
     "immer": "10.1.1",
     "lodash": "4.17.21",
-    "prop-types": "15.8.1",
     "react": "19.1.0",
     "use-immer": "0.11.0",
     "uuid": "11.1.0"
@@ -84,6 +83,7 @@
     "@vitest/coverage-istanbul": "3.0.9",
     "@vitest/ui": "3.0.9",
     "jsdom": "26.0.0",
+    "prop-types": "^15.8.1",
     "sass": "1.86.0",
     "typescript": "5.8.2",
     "vite": "6.2.2",

--- a/@utahdts/utah-design-system/package.json
+++ b/@utahdts/utah-design-system/package.json
@@ -72,7 +72,6 @@
     "lodash": "4.17.21",
     "prop-types": "15.8.1",
     "react": "19.1.0",
-    "react-dom": "19.1.0",
     "use-immer": "0.11.0",
     "uuid": "11.1.0"
   },

--- a/@utahdts/utah-design-system/vite.config.js
+++ b/@utahdts/utah-design-system/vite.config.js
@@ -37,12 +37,21 @@ export default defineConfig(({ mode }) => {
       rollupOptions: {
         // make sure to externalize deps that shouldn't be bundled
         // into your library
-        external: ['react', '@utahdts/utah-design-system-header'],
+        external: ['react', 'react/jsx-runtime', 'react-dom', '@floating-ui/react-dom', 'date-fns', 'immer', 'lodash', 'use-immer', 'uuid', '@utahdts/utah-design-system-header'],
         output: {
           // Provide global variables to use in the UMD build
           // for externalized deps
           globals: {
-            react: 'React'
+            react: 'React',
+            'react/jsx-runtime': 'jsxRuntime',
+            'react-dom': 'ReactDOM',
+            'date-fns': 'dateFns',
+            '@floating-ui/react-dom': '@floating-ui/react-dom',
+            '@utahdts/utah-design-system-header': '@utahdts/utah-design-system-header',
+            immer: 'immer',
+            lodash: 'lodash',
+            'use-immer': 'useImmer',
+            uuid: 'uuid',
           },
         },
       },


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ab612916-ab93-43f6-b5d5-3c8a04e03fe4)

I believe the utah-design-system bundle is misconfigured. It appears to be bundling a version of react and many other tools that are not necessary and are fouling up an app I inherited from your group.

The way I understand it, all dependencies should be external to the bundle so the package manager can resolve them during an install.

`react-dom` should not be a dependency at all since you aren't mounting anything.

This takes you from 410KB
<img width="1407" alt="image" src="https://github.com/user-attachments/assets/08a3face-0ab6-4c2b-8ebd-8ad5a6750bf3" />
to 280KB
<img width="1406" alt="image" src="https://github.com/user-attachments/assets/0a1b3f68-8e1e-4772-b7c6-2bee366b7a12" />


