### PR TITLE
Main menu skip

### DIFF
--- a/@utahdts/utah-design-system-header/src/@types/jsDocTypes.d.js
+++ b/@utahdts/utah-design-system-header/src/@types/jsDocTypes.d.js
@@ -149,7 +149,8 @@
  *  @property {function(UIEvent): void} [onClick] custom onclick handler
  *  @property {PopupPlacement} [popupPlacement] which side should the popup place itself (defaults to bottom and Floating UI will place where it can)
  *  @property {boolean} [preventOnClickHandling] turns off click handling for popup invocation
- *  @property {boolean} [shouldFocusOnHover] will perform the popup on hover as well as the focus event
+ *  @property {boolean} [shouldFocusOnHover] will perform the popup on hover
+ *  @property {boolean} [shouldFocusOnTab] will perform the popup on focus event
  *  @property {boolean} [doNotClosePopupOnClick] main menu items should not close popup when it's clicked
  * }
  */

--- a/@utahdts/utah-design-system-header/src/js/misc/allowAriaExpanded.js
+++ b/@utahdts/utah-design-system-header/src/js/misc/allowAriaExpanded.js
@@ -1,6 +1,6 @@
 /**
  * menus do not use aria-expanded because the popups are always rendered and only
- * shown/hid. Yet to spring readers, they are always visible so they don't need to
+ * shown/hid. Yet to screen readers, they are always visible so they don't need to
  * report expanded.
  * @param {Element} element
  * @returns {boolean}

--- a/@utahdts/utah-design-system-header/src/js/renderables/popupMenu/renderPopupMenu.js
+++ b/@utahdts/utah-design-system-header/src/js/renderables/popupMenu/renderPopupMenu.js
@@ -172,7 +172,7 @@ function renderPopupMenuItem(menuUl, popupMenuItem, options) {
           'menu',
           {
             popupPlacement: PopupPlacement.RIGHT_START,
-            preventOnClickHandling: true,
+            preventOnClickHandling: false,
             shouldFocusOnHover: true,
           }
         );

--- a/@utahdts/utah-design-system-header/src/js/renderables/popupMenu/renderPopupMenu.js
+++ b/@utahdts/utah-design-system-header/src/js/renderables/popupMenu/renderPopupMenu.js
@@ -1,7 +1,6 @@
 import { childrenMenuTypes } from '../../enumerations/childrenMenuTypes';
 import { domConstants, getCssClassSelector } from '../../enumerations/domConstants';
 import { PopupPlacement } from '../../enumerations/popupPlacement';
-import { allowAriaExpanded } from '../../misc/allowAriaExpanded';
 import { findRecursive } from '../../misc/findRecursive';
 import { popupFocusHandler } from '../../misc/popupFocusHandler';
 import { renderDOMSingle } from '../../misc/renderDOMSingle';
@@ -41,15 +40,13 @@ function toggleChildMenuExpansion(element) {
       // toggle child menu items open close
       childUl.classList.toggle(domConstants.VISUALLY_HIDDEN);
       if (childUl.classList.contains(domConstants.VISUALLY_HIDDEN)) {
-        if (allowAriaExpanded(button)) {
-          button.setAttribute('aria-expanded', 'false');
-        }
+        button.setAttribute('aria-expanded', 'false');
+        childUl.setAttribute('inert', 'true');
         chevron.classList.add(domConstants.IS_CLOSED);
         chevron.classList.remove(domConstants.IS_OPEN);
       } else {
-        if (allowAriaExpanded(button)) {
-          button.setAttribute('aria-expanded', 'true');
-        }
+        button.setAttribute('aria-expanded', 'true');
+        childUl.removeAttribute('inert');
         chevron.classList.remove(domConstants.IS_CLOSED);
         chevron.classList.add(domConstants.IS_OPEN);
       }
@@ -190,11 +187,10 @@ function renderPopupMenuItem(menuUl, popupMenuItem, options) {
         subMenu.setAttribute('id', subMenuId);
         // these are all sub children so hide them initially
         subMenu.classList.add(domConstants.VISUALLY_HIDDEN);
+        subMenu.setAttribute('inert', 'true');
         menuItemWrapper.appendChild(subMenu);
         menuButton.onclick = handleMenuExpansion(menuButton);
-        if (allowAriaExpanded(menuButton)) {
-          menuButton.setAttribute('aria-expanded', 'false');
-        }
+        menuButton.setAttribute('aria-expanded', 'false');
         menuButton.setAttribute('aria-controls', subMenuId);
         chevron = renderChevron();
         menuButton.appendChild(chevron);
@@ -203,14 +199,13 @@ function renderPopupMenuItem(menuUl, popupMenuItem, options) {
         plainTitle.remove();
 
         // open all parent uls so that this menu item shows
-        menuItemWrapper.addEventListener('focusin', (e) => {
+        menuItemWrapper.addEventListener('click', (e) => {
           // Do not stop propagation as trickling-up will make parents open
           // if e.target is switched to e.currenttarget then tabbing through child popup menus does not open the children
           for (let childUl = /** @type {Element | null | undefined} */(e.target)?.closest('ul'); childUl; childUl = childUl.parentElement?.closest('ul')) {
             childUl.classList.remove(domConstants.VISUALLY_HIDDEN);
-            if (allowAriaExpanded(menuButton)) {
-              menuButton.setAttribute('aria-expanded', 'true');
-            }
+            subMenu.removeAttribute('inert');
+            menuButton.setAttribute('aria-expanded', 'true');
             // if target is the button then don't expand chevron just yet, wait for a child to be visible
             // (happens when tabbing to the chevron menu item)
             // using e.currentTarget caused the chevron to expand on the parent before the children were tabbed into

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/buttons/button/ButtonDocumentation.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/buttons/button/ButtonDocumentation.jsx
@@ -443,12 +443,12 @@ export function ButtonDocumentation() {
       </ul>
       <h4 id="section-keyboard-interactivity">Keyboard interactivity</h4>
       <ul className="mb-spacing">
-        <li>The button must receive focus when the user presses the <code>tab</code> key.
+        <li>The button must receive focus when the user presses the <code>Tab</code> key.
           <ul>
             <li>Buttons natively receive keyboard focus so there&apos;s no need to add a tabindex attribute.</li>
           </ul>
         </li>
-        <li>You should be able to press the button by using the <code>enter</code> or <code>space</code> key.</li>
+        <li>You should be able to press the button by using the <code>Enter</code> or <code>Space</code> key.</li>
 
       </ul>
       <h4 id="section-screen-readers">Screen readers</h4>

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/buttons/confirmationButton/ConfirmationButtonDocumentation.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/buttons/confirmationButton/ConfirmationButtonDocumentation.jsx
@@ -162,10 +162,10 @@ export function ConfirmationButtonDocumentation() {
       <h4>Keyboard Interactivity</h4>
       <ul className="mb-spacing">
         <li>
-          The button should display a visible focus state when users tab to it. Pressing the <code>spacebar</code> or <code>return</code> key will
+          The button should display a visible focus state when users tab to it. Pressing the <code>Spacebar</code> or <code>Return</code> key will
           activate
           the initial action of the button. When the confirmation text is shown in the button, the user can confirm their selection
-          by pressing the <code>spacebar</code> or <code>return</code> key again. Alternately the user may cancel the action by hitting
+          by pressing the <code>Spacebar</code> or <code>Return</code> key again. Alternately the user may cancel the action by hitting
           the <code>escape</code> key.
         </li>
         <li>
@@ -173,7 +173,7 @@ export function ConfirmationButtonDocumentation() {
         </li>
         <li>
           When you much us aria, ensure elements with ARIA <code>role=&quot;button&quot;</code> can be activated with both key commands (Pressing
-          the <code>spacebar</code> or <code>return</code> key).
+          the <code>Spacebar</code> or <code>Return</code> key).
         </li>
         <li>
           Remember, the first rule of ARIA: Before you use ARIA, use native HTML elements or attributes first!

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/buttons/iconButton/IconButtonDocumentation.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/buttons/iconButton/IconButtonDocumentation.jsx
@@ -405,14 +405,14 @@ export function IconButtonDocumentation() {
       </ul>
       <h4 id="section-keyboard-interactivity">Keyboard interactivity</h4>
       <ul className="mb-spacing">
-        <li>The icon button must receive focus when the user presses the <code>tab</code> key.
+        <li>The icon button must receive focus when the user presses the <code>Tab</code> key.
           <ul>
             <li>Buttons natively receive keyboard focus so there&apos;s no need to add a tabindex attribute.</li>
           </ul>
         </li>
         <li>When the icon button receives focus, the tooltip should be visible (except when the icon button displays a popup).</li>
         <li>The icon button should display a visible focus state when users tab to it.</li>
-        <li>You should be able to press the button by using the <code>enter</code> or <code>space</code> key.</li>
+        <li>You should be able to press the button by using the <code>Enter</code> or <code>Space</code> key.</li>
       </ul>
       <h4 id="section-screen-readers">Screen readers</h4>
       <ul className="mb-spacing">

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/buttons/tag/TagsDocumentation.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/buttons/tag/TagsDocumentation.jsx
@@ -256,7 +256,7 @@ export function TagsDocumentation() {
           provides the required keyboard navigability.
         </li>
         <li>
-          Use the <code>tab</code> key to move between form elements. An interactive tag should display a visible focus state when users tab to them.
+          Use the <code>Tab</code> key to move between form elements. An interactive tag should display a visible focus state when users tab to them.
         </li>
       </ul>
 

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/containers/Accordion/AccordionDocumentation.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/containers/Accordion/AccordionDocumentation.jsx
@@ -173,7 +173,7 @@ export function AccordionDocumentation() {
       <h4>Keyboard Interactivity</h4>
       <ul className="mb-spacing">
         <li>
-          Every accordion within the component is a tab stop, and can be expanded or collapsed using the <code>space</code> or <code>enter</code> keys.
+          Every accordion within the component is a tab stop, and can be expanded or collapsed using the <code>Space</code> or <code>Enter</code> keys.
           By default, the accordions are collapsed. When an accordion is expanded, its interactive elements are automatically integrated into
           the tab order.
         </li>

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/containers/Card/CardDocumentation.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/containers/Card/CardDocumentation.jsx
@@ -381,14 +381,14 @@ export function CardDocumentation() {
 
       <h4>Keyboard Interactivity</h4>
       <ul className="mb-spacing">
-        <li>The tab key should take the user through the elements of the card.</li>
+        <li>The <code>Tab</code> key should take the user through the elements of the card.</li>
         <li>Make sure that users can clearly see where the focus is when navigating with a keyboard or assistive technology by providing clear focus styles.</li>
         <li>
           Action cards
           <ul>
             <li>Wrap the entire action card in a <code>&lt;button&gt;</code>, or use the <code>role=&quot;button&quot;</code>.</li>
             <li>Use <code>tabindex=&quot;0&quot;</code> if you are not using a <code>&lt;button&gt;</code>.</li>
-            <li>The <code>enter</code> or <code>return</code> keys should take the user to the corresponding page.</li>
+            <li>The <code>Enter</code> or <code>Return</code> keys should take the user to the corresponding page.</li>
           </ul>
         </li>
       </ul>

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/containers/Drawer/DrawerDocumentation.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/containers/Drawer/DrawerDocumentation.jsx
@@ -107,7 +107,7 @@ export function DrawerDocumentation() {
       <h4>Keyboard Interactivity</h4>
       <ul className="mb-spacing">
         <li>Upon opening, focus should be put on the first element within the drawer.</li>
-        <li>Using the <code>tab</code> key, the user should only navigate through elements within the drawer.</li>
+        <li>Using the <code>Tab</code> key, the user should only navigate through elements within the drawer.</li>
         <li>If the drawer includes a close button, pressing the <code>esc</code> key should close the drawer. The close button should be the last
           focusable element.
         </li>

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/containers/TabGroup/TabGroupDocumentation.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/containers/TabGroup/TabGroupDocumentation.jsx
@@ -161,10 +161,10 @@ export function TabGroupDocumentation() {
       <h4 id="section-keyboard-interactivity">Keyboard interactivity</h4>
       <ul className="mb-spacing">
         <li>
-          When the user hits the <code>tab</code> key to navigate to the tab group, the focus should be placed on the active tab.
+          When the user hits the <code>Tab</code> key to navigate to the tab group, the focus should be placed on the active tab.
         </li>
         <li>
-          Hitting <code>tab</code> after focus has been placed on the active tab will move the focus to the next interactive element
+          Hitting <code>Tab</code> after focus has been placed on the active tab will move the focus to the next interactive element
           outside the tab list (whether it be inside a tab panel or outside the tab group).
         </li>
         <li>
@@ -175,7 +175,7 @@ export function TabGroupDocumentation() {
           tab.
         </li>
         <li>
-          It is recommended that tabs activate automatically following focus. If not, hitting the <code>spacebar</code> or <code>enter</code> should
+          It is recommended that tabs activate automatically following focus. If not, hitting the <code>Spacebar</code> or <code>Enter</code> should
           activate the tab and display the panel associated with it.
         </li>
       </ul>

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/forms/Checkbox/CheckboxDocumentation.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/forms/Checkbox/CheckboxDocumentation.jsx
@@ -107,8 +107,8 @@ export function CheckboxDocumentation() {
 
       <h4>Keyboard Interactivity</h4>
       <ul className="mb-spacing">
-        <li>The user should be able to navigate through a list of checkboxes using the <code>tab</code> key.</li>
-        <li>Once on focus, hitting the <code>spacebar</code> should select or deselect the checkbox.</li>
+        <li>The user should be able to navigate through a list of checkboxes using the <code>Tab</code> key.</li>
+        <li>Once on focus, hitting the <code>Spacebar</code> should select or deselect the checkbox.</li>
       </ul>
 
       <h4>Screen Readers</h4>

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/forms/DateInput/DateInputDocumentation.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/forms/DateInput/DateInputDocumentation.jsx
@@ -127,9 +127,9 @@ export function DateInputDocumentation() {
       </ul>
       <h4>Keyboard Interactivity</h4>
       <ul className="mb-spacing">
-        <li>You should be able to navigate the entire date popup using only the keyboard. Pressing <code>return</code> or <code>space</code> on the calendar icon button will cause the date picker popup to appear. Focus will be automatically set to the selected date.</li>
+        <li>You should be able to navigate the entire date popup using only the keyboard. Pressing <code>Return</code> or <code>Space</code> on the calendar icon button will cause the date picker popup to appear. Focus will be automatically set to the selected date.</li>
         <li>You can close the popup by hitting the <code>escape</code> key.</li>
-        <li>The <code>tab</code> key will focus on the month and year arrows, the currently selected day, and the &quot;today&quot; button.</li>
+        <li>The <code>Tab</code> key will focus on the month and year arrows, the currently selected day, and the &quot;today&quot; button.</li>
         <li>When the user presses &quot;return/enter&quot; the date picker popup will close with the highlighted date being added to the input field.</li>
         <li>Additionally you may navigate the date picker popup with the following keyboard shortcuts (Mac-equivalent commands are in parentheses):
           <ul>

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/forms/FileInput/FileInputDocumentation.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/forms/FileInput/FileInputDocumentation.jsx
@@ -108,9 +108,9 @@ export function FileInputDocumentation() {
       <h4>Keyboard Interactivity</h4>
       <ul className="mb-spacing">
         <li>The file input should behave like a <Link to={pageUrls.button}>button</Link> to a user. Hitting
-          the <code>spacebar</code> or <code>enter</code> key should prompt the user to select a file.
+          the <code>Spacebar</code> or <code>Enter</code> key should prompt the user to select a file.
         </li>
-        <li>The file input should receive focus when the user presses the <code>tab</code> key.</li>
+        <li>The file input should receive focus when the user presses the <code>Tab</code> key.</li>
         <li>
           Do not only accept files via drag and drop.
           You must provide a focusable element (button or file input) that the user can trigger using only the keyboard.

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/forms/RadioButton/RadioButtonDocumentation.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/forms/RadioButton/RadioButtonDocumentation.jsx
@@ -106,7 +106,7 @@ export function RadioButtonDocumentation() {
 
       <h4>Keyboard Interactivity</h4>
       <ul className="mb-spacing">
-        <li>The user should be able to navigate into and out of a radio button group using the <code>tab</code> key.</li>
+        <li>The user should be able to navigate into and out of a radio button group using the <code>Tab</code> key.</li>
         <li>The user should be able to navigate and make their selection through the list of options using
           the <code>up</code> and <code>down</code> or <code>left</code> and <code>right</code> arrow keys.
         </li>

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/forms/Switch/SwitchDocumentation.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/forms/Switch/SwitchDocumentation.jsx
@@ -212,8 +212,8 @@ export function SwitchDocumentation() {
 
       <h4 id="section-keyboard-interactivity">Keyboard interactivity</h4>
       <ul className="mb-spacing">
-        <li>Use the <code>tab</code> key to move between form elements. The switch should display a visible focus state when users tab to it.</li>
-        <li>A switch component can be triggered by pressing the <code>spacebar</code>.</li>
+        <li>Use the <code>Tab</code> key to move between form elements. The switch should display a visible focus state when users tab to it.</li>
+        <li>A switch component can be triggered by pressing the <code>Spacebar</code>.</li>
       </ul>
 
       <h4 id="section-screen-readers">Screen readers</h4>

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/forms/TextArea/TextAreaDocumentation.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/forms/TextArea/TextAreaDocumentation.jsx
@@ -145,7 +145,7 @@ export function TextAreaDocumentation() {
 
       <h4>Keyboard Interactivity</h4>
       <ul className="mb-spacing">
-        <li>When navigating the form, the user should be able to move in and out of focus on the text area using the <code>tab</code> key.</li>
+        <li>When navigating the form, the user should be able to move in and out of focus on the text area using the <code>Tab</code> key.</li>
       </ul>
 
       <h4>Screen Readers</h4>

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/forms/TextInput/TextInputDocumentation.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/forms/TextInput/TextInputDocumentation.jsx
@@ -75,7 +75,7 @@ export function TextInputDocumentation() {
             <li>To the left of the placeholder there should be a magnifying glass icon to signify that this is a search input box.</li>
             <li>Optionally, you may place an <Link to={pageUrls.icons}><code><span className="uds-icon" aria-label="X" style={{verticalAlign: 'middle'}}>&#xe917;</span> icon</code></Link> on the right to clear the input field.</li>
             <li>There should be a submit button (visible or visually-hidden) to trigger the search.</li>
-            <li>Use an event handler to trigger the search when the user presses <code>return</code> or <code>enter</code>.</li>
+            <li>Use an event handler to trigger the search when the user presses <code>Return</code> or <code>Enter</code>.</li>
           </ul>
         )}
       />
@@ -144,7 +144,7 @@ export function TextInputDocumentation() {
       </ul>
       <h4>Keyboard Interactivity</h4>
       <ul className="mb-spacing">
-        <li>When navigating the form, the user should be able to move in and out of focus on the text area using the <code>tab</code> key.</li>
+        <li>When navigating the form, the user should be able to move in and out of focus on the text area using the <code>Tab</code> key.</li>
       </ul>
       <h4>Screen Readers</h4>
       <ul className="mb-spacing">

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/forms/TimeInput/TimeInputDocumentation.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/forms/TimeInput/TimeInputDocumentation.jsx
@@ -184,7 +184,7 @@ export function TimeInputDocumentation() {
               the <Link to={pageUrls.iconButton}>icon button</Link> that houses the <Link to={pageUrls.popups}>popup menu</Link>.
             </li>
             <li>
-              <code>Arrows (left and right)</code> or tab keys should move the user between the hour, minute, and time of day inputs.
+              <code>Arrows (left and right)</code> or <code>Tab</code> keys should move the user between the hour, minute, and time of day inputs.
             </li>
             <li>
               <code>Enter</code> or <code>Space</code> key should open the <Link to={pageUrls.popups}>popup</Link>.

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/links/LinksDocumentation.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/links/LinksDocumentation.jsx
@@ -131,7 +131,7 @@ export function LinksDocumentation() {
 
       <h4 id="section-keyboard-interactivity">Keyboard interactivity</h4>
       <ul className="mb-spacing">
-        <li>Users must be able to navigate to a link using the tab key. (There must be some indicator that the link has received focus.)</li>
+        <li>Users must be able to navigate to a link using the <code>Tab</code> key. (There must be some indicator that the link has received focus.)</li>
         <li>Users must be able to select the link item using the Enter/Return key</li>
         <li>Using <code>tabindex=&quot;0&quot;</code> inserts the element into the tab order, thus allowing the element to gain focus using the tab key </li>
       </ul>

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/navigation/Breadcrumb/BreadcrumbDocumentation.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/navigation/Breadcrumb/BreadcrumbDocumentation.jsx
@@ -162,8 +162,8 @@ export function BreadcrumbDocumentation() {
 
       <h4 id="section-keyboard-interactivity">Keyboard interactivity</h4>
       <ul className="mb-spacing">
-        <li>The <code>tab</code> key should take the user through the breadcrumb trail.</li>
-        <li>The <code>enter</code> or <code>return</code> keys should take the user to the corresponding page.</li>
+        <li>The <code>Tab</code> key should take the user through the breadcrumb trail.</li>
+        <li>The <code>Enter</code> or <code>Return</code> keys should take the user to the corresponding page.</li>
       </ul>
       <h4 id="section-screen-readers">Screen readers</h4>
       <ul className="mb-spacing">

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/navigation/HamburgerMenu/HamburgerMenuDocumentation.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/navigation/HamburgerMenu/HamburgerMenuDocumentation.jsx
@@ -74,8 +74,8 @@ export function HamburgerMenuDocumentation() {
 
       <h4 id="section-keyboard-interactivity">Keyboard interactivity</h4>
       <ul className="mb-spacing">
-        <li>The hamburger button should be able to receive focus by hitting the <code>tab</code> key.</li>
-        <li>Hitting <code>enter</code> or <code>spacebar</code> triggers the opening or closing of the menu.</li>
+        <li>The hamburger button should be able to receive focus by hitting the <code>Tab</code> key.</li>
+        <li>Hitting <code>Enter</code> or <code>Spacebar</code> triggers the opening or closing of the menu.</li>
         <li>Once the menu is opened, hitting the <code>esc</code> key should close the menu.</li>
         <li>The next focusable element should be the first link within the menu.</li>
         <li>When leaving the menu, the next focusable element should be the hamburger button (x).</li>

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/navigation/MainMenu/MainMenuDocumentation.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/navigation/MainMenu/MainMenuDocumentation.jsx
@@ -71,7 +71,7 @@ export function MainMenuDocumentation() {
       </ul>
       <h4 id="section-keyboard-interactivity" className="mt-spacing">Keyboard Interactivity</h4>
       <ul>
-        <li>Users must be able to to navigate using the <code>tab</code> key.</li>
+        <li>Users must be able to navigate using the <code>Tab</code> key.</li>
         <li>Users must be able to select the navigation item using the <code>Enter/Return</code> keys.</li>
       </ul>
       <h4 id="section-screen-readers" className="mt-spacing">Screen Readers</h4>

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/navigation/verticalMenu/VerticalMenuDocumentation.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/navigation/verticalMenu/VerticalMenuDocumentation.jsx
@@ -237,7 +237,8 @@ export function VerticalMenuDocumentation() {
       </ul>
       <h4>Keyboard Interactivity</h4>
       <ul className="mb-spacing">
-        <li>The user should be able to easily navigate the entire menu with a <code>tab</code> key.</li>
+        <li>The user should be able to easily navigate the entire menu with a <code>Tab</code> key.</li>
+        <li>The user should be able to access sub-menus with the <code>Enter/Return</code> or <code>Space</code> key.</li>
       </ul>
       <h4>Screen Readers</h4>
       <ul className="mb-spacing">

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/popups/banners/BannersDocumentation.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/popups/banners/BannersDocumentation.jsx
@@ -364,7 +364,7 @@ export function BannersDocumentation() {
       <ul className="mb-spacing">
         <li>Floating banners do not receive focus.</li>
         <li>
-          Users can close a landmark banner by pressing the <code>spacebar</code> while the close{' '}
+          Users can close a landmark banner by pressing the <code>Spacebar</code> while the close{' '}
           <Link to={pageUrls.iconButton}>icon button</Link> has focus.
         </li>
       </ul>

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/popups/modals/ModalsDocumentation.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/popups/modals/ModalsDocumentation.jsx
@@ -133,13 +133,13 @@ export function ModalsDocumentation() {
       </ul>
       <h4 id="section-keyboard-interactivity">Keyboard interactivity</h4>
       <ul className="mb-spacing">
-        <li>Once the user triggers the modal, the modal will automatically receive focus, hitting the <code>tab</code> key should put the focus on the
+        <li>Once the user triggers the modal, the modal will automatically receive focus, hitting the <code>Tab</code> key should put the focus on the
           first tabbable element within the modal.
         </li>
-        <li>Using the <code>tab</code> key, the user should be able to only navigate through elements within the modal. When the user tabs to the last
-          element of the modal the next <code>tab</code> key press should return them to the beginning of the modal again.
+        <li>Using the <code>Tab</code> key, the user should be able to only navigate through elements within the modal. When the user tabs to the last
+          element of the modal the next <code>Tab</code> key press should return them to the beginning of the modal again.
         </li>
-        <li>If the modal includes a <code>close</code> button, pressing the <code>esc</code> key should close the modal. The <code>close</code> button
+        <li>If the modal includes a <code>Close</code> button, pressing the <code>Esc</code> key should close the modal. The <code>close</code> button
           should be the last focusable element.
         </li>
         <li>When closing the modal, the focus should be returned on the element that triggered it.</li>

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/sliders/carousel/CarouselDocumentation.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/sliders/carousel/CarouselDocumentation.jsx
@@ -92,7 +92,7 @@ export function CarouselDocumentation() {
         <li>Once the carousel receives focus, rotation should be paused until the user explicitly turns it back on or leaves focus.</li>
         <li>If the carousel has a <Link to={pageUrls.button}>button</Link> to pause rotation, it should be the first focusable element.</li>
         <li>If the carousel includes a list of controls, selecting one of those controls should rotate the carousel to its associated slide. The focus should then be placed on the slide.</li>
-        <li>Controls can be activated by hitting <code>enter</code> or <code>spacebar</code>.</li>
+        <li>Controls can be activated by hitting <code>Enter</code> or <code>Spacebar</code>.</li>
       </ul>
 
       <h4 id="section-screen-readers">Screen readers</h4>

--- a/utah-design-system-website/src/react/components/websiteContent/library/components/widgetsIndicators/stepIndicator/StepIndicatorDocumentation.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/components/widgetsIndicators/stepIndicator/StepIndicatorDocumentation.jsx
@@ -153,8 +153,8 @@ export function StepIndicatorDocumentation() {
       <h4 id="section-keyboard-interactivity">Keyboard interactivity</h4>
       <ul className="mb-spacing">
         <li>
-          When a user is allowed to navigate by the step indicators, use the <code>tab</code> key to navigate to each enabled step.
-          Use <code>space</code> or <code>enter</code> to select the step.
+          When a user is allowed to navigate by the step indicators, use the <code>Tab</code> key to navigate to each enabled step.
+          Use <code>Space</code> or <code>Enter</code> to select the step.
         </li>
       </ul>
 

--- a/utah-design-system-website/src/react/components/websiteContent/library/patterns/UtahFooterDocumentation/UtahFooterDocumentation.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/patterns/UtahFooterDocumentation/UtahFooterDocumentation.jsx
@@ -92,8 +92,8 @@ export function UtahFooterDocumentation() {
       </ul>
       <h4 id="section-keyboard-interactivity">Keyboard interactivity</h4>
       <ul className="mb-spacing">
-        <li>Users must be able to to navigate using the tab key</li>
-        <li>Users must be able to select the navigation item using the Enter/Return key</li>
+        <li>Users must be able to to navigate using the <code>Tab</code> key</li>
+        <li>Users must be able to select the navigation item using the <code>Enter/Return</code> key</li>
       </ul>
       <h4 id="section-screen-readers">Screen readers</h4>
       <ul className="mb-spacing">

--- a/utah-design-system-website/src/react/components/websiteContent/library/patterns/UtahHeaderDocumentation/UtahHeaderDocumentation.jsx
+++ b/utah-design-system-website/src/react/components/websiteContent/library/patterns/UtahHeaderDocumentation/UtahHeaderDocumentation.jsx
@@ -435,7 +435,7 @@ export function UtahHeaderDocumentation() {
       </ul>
       <h4 id="section-keyboard-interactivity" className="mt-spacing">Keyboard Interactivity</h4>
       <ul>
-        <li>Users must be able to to navigate using the <code>tab</code> key.</li>
+        <li>Users must be able to to navigate using the <code>Tab</code> key.</li>
         <li>Users must be able to select the navigation item using the <code>Enter/Return</code> keys.</li>
       </ul>
       <h4 id="section-screen-readers" className="mt-spacing">Screen Readers</h4>


### PR DESCRIPTION
This change makes it so that first-level menu items can be navigated with a keyboard, without having to go through sub-menus.

The approach is to make sub-menus "[inert](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/inert)" until the user clicks (press enter or space) the item.
One of the downside of using "inert" is that it [hides all content from screen readers](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/inert#accessibility_concerns). To deal with that, "aria-expanded" has been added to the buttons.

Desktop version:
- A new property has been added: "shouldFocusOnTab". By default it is turned **off**. Turning it on would open the sub-menu while tabbing through.
- 'focusin' and 'focusout' events were handled through anonymous functions. Since they couldn't be removed, two handlers have been created instead.

Updated the documentation to capitalize keys: tab → Tab, enter → Enter, etc.