### PR TITLE
Switch to more reliable page unload event

### DIFF
--- a/@utahdts/utah-design-system-header/src/js/settings/settings.js
+++ b/@utahdts/utah-design-system-header/src/js/settings/settings.js
@@ -40,7 +40,7 @@ const intervalId = setInterval(
   2
 );
 
-window.addEventListener('unload', ()=> {
+window.addEventListener('pagehide', ()=> {
   clearInterval(intervalId);
 });
 


### PR DESCRIPTION
I found this when looking at a Google Lighthouse report. It flagged the use of the `unload` event and referenced this doc: https://web.dev/articles/bfcache#never-use-the-unload-event

Also see MDN: https://developer.mozilla.org/en-US/docs/Web/API/Window/unload_event#usage_notes